### PR TITLE
add export setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ To enable this feature, add the following code to your `settings.json`:
 
 **Warning**: there is a side effect when you enable this feature: a revision is created everytime the text is highlighted, resulting on apparently "empty" changes when you check your pad on the timeslider. If that is an issue for you, we don't recommend you to use this feature.
 
+### Disable HTML export
+By default comments are exported to HTML, but if you don't wish to do that then you can disable it by adding the following to your `settings.json`:
+```
+"ep_comments_page": {
+  "exportHtml": false
+},
+```
+
 ## Creating comment via API
 If you need to add comments to a pad:
 

--- a/exportHTML.js
+++ b/exportHTML.js
@@ -2,6 +2,7 @@
 
 const $ = require('ep_etherpad-lite/node_modules/cheerio');
 const commentManager = require('./commentManager');
+const settings = require('ep_etherpad-lite/node/utils/Settings');
 
 // Iterate over pad attributes to find only the comment ones
 const findAllCommentUsedOn = (pad) => {
@@ -15,6 +16,7 @@ exports.exportHtmlAdditionalTagsWithData =
   async (hookName, pad) => findAllCommentUsedOn(pad).map((name) => ['comment', name]);
 
 exports.getLineHTMLForExport = async (hookName, context) => {
+  if (settings.ep_comments_page && settings.ep_comments_page.exportHtml === false) return;
   // I'm not sure how optimal this is - it will do a database lookup for each line..
   const {comments} = await commentManager.getComments(context.padId);
   // Load the HTML into a throwaway div instead of calling $.load() to avoid
@@ -38,6 +40,7 @@ exports.getLineHTMLForExport = async (hookName, context) => {
 };
 
 exports.exportHTMLAdditionalContent = async (hookName, {padId}) => {
+  if (settings.ep_comments_page && settings.ep_comments_page.exportHtml === false) return;
   const {comments} = await commentManager.getComments(padId);
   if (!comments) return;
   const div = $('<div>').attr('id', 'comments');


### PR DESCRIPTION
As this HTML export seems broken and we at out project don't want to export HTML anyway I added a setting option to skip export. Default behaviour is exporting but if `settings.ep_comments_page.exportHTML = false;` export is skipped