### PR TITLE
Async hook fixes and test fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,10 @@ exports.padRemove = (hookName, context) => {
 };
 
 exports.padCopy = async (hookName, context) => {
-  commentManager.copyComments(context.originalPad.id, context.destinationID);
-  commentManager.copyCommentReplies(context.originalPad.id, context.destinationID);
+  await Promise.all([
+    commentManager.copyComments(context.originalPad.id, context.destinationID),
+    commentManager.copyCommentReplies(context.originalPad.id, context.destinationID),
+  ]);
 };
 
 exports.handleMessageSecurity = (hookName, context, callback) => {

--- a/index.js
+++ b/index.js
@@ -12,9 +12,11 @@ let io;
 
 exports.exportEtherpadAdditionalContent = (hookName, context, callback) => callback(['comments']);
 
-exports.padRemove = (hookName, context) => {
-  commentManager.deleteCommentReplies(context.padID);
-  commentManager.deleteComments(context.padID);
+exports.padRemove = async (hookName, context) => {
+  await Promise.all([
+    commentManager.deleteCommentReplies(context.padID),
+    commentManager.deleteComments(context.padID),
+  ]);
 };
 
 exports.padCopy = async (hookName, context) => {

--- a/static/tests/backend/specs/api/exportHTML.js
+++ b/static/tests/backend/specs/api/exportHTML.js
@@ -1,13 +1,12 @@
 'use strict';
 
-function m(mod) { return `${__dirname}/../../../../../../../tests/backend/${mod}`; }
 const utils = require('../../../utils');
 const apiKey = utils.apiKey;
 const codeToBe0 = utils.codeToBe0;
 const apiVersion = utils.apiVersion;
 const randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
 const settings = require('ep_etherpad-lite/node/utils/Settings');
-const common = require(m('common'));
+const common = require('ep_etherpad-lite/tests/backend/common');
 const db = require('ep_etherpad-lite/node/db/DB');
 let agent;
 

--- a/static/tests/backend/specs/padCopy.js
+++ b/static/tests/backend/specs/padCopy.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const supertest = require('../../../../node_modules/supertest');
+const supertest = require('supertest');
 const utils = require('../../utils');
 const createPad = utils.createPad;
 const createComment = utils.createComment;


### PR DESCRIPTION
Multiple commits:
* Revert "padCopy callback issue"
* Fix `padRemove()` sync call of comment manager functions
* tests: Fix `require` path for common helper module

This should be merged after ether/etherpad-lite#4685 and ether/etherpad-lite#4686 are merged.