### PR TITLE
Improve und standardize translation

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -3,7 +3,7 @@
   "ep_comments_page.comments" : "Kommentare",
   "ep_comments_page.add_comment.title" : "Kommentar zur Auswahl hinzufügen",
   "ep_comments_page.add_comment" : "Kommentar zur Auswahl hinzufügen",
-  "ep_comments_page.add_comment.hint" : "Bitte wählen Sie zuerst den zu kommentierenden Text aus",
+  "ep_comments_page.add_comment.hint" : "Bitte wähle zuerst den zu kommentierenden Text aus!",
   "ep_comments_page.delete_comment.title" : "Diesen Kommentar löschen",
   "ep_comments_page.show_comments" : "Kommentare anzeigen",
   "ep_comments_page.comments_template.suggested_change" : "Vorgeschlagene Änderung",


### PR DESCRIPTION
In etherpad we don't use the polite german form (Sie). This should also be the case in all plugins.