### PR TITLE
More robust socket callbacks

### DIFF
--- a/static/tests/backend/specs/api/commentReplies.js
+++ b/static/tests/backend/specs/api/commentReplies.js
@@ -259,7 +259,7 @@ describe('create comment reply API broadcast', function () {
         const req = {padId: padID};
         // needs to get comments to be able to join the pad room, where the messages will be
         // broadcast to:
-        socket.emit('getComments', req, (res) => {
+        socket.emit('getComments', req, (errj, res) => {
           socket.on('pushAddCommentReply', (data) => {
             ++timesMessageWasReceived;
           });

--- a/static/tests/backend/specs/api/comments.js
+++ b/static/tests/backend/specs/api/comments.js
@@ -238,7 +238,7 @@ describe('create comment API broadcast', function () {
       const req = {padId: padID};
       // needs to get comments to be able to join the pad room, where the messages will be broadcast
       // to:
-      socket.emit('getComments', req, (res) => {
+      socket.emit('getComments', req, (errj, res) => {
         socket.on('pushAddComment', (data) => {
           ++timesMessageWasReceived;
         });


### PR DESCRIPTION
Avoid etherpad crashes. For example:

```
^[[31m[2021-04-13 15:49:04.773] [ERROR] server - ^[[39mTypeError: Cannot set property 'changeAccepted' of undefined
    at Object.exports.changeAcceptedState (.../node_modules/ep_comments_page/commentManager.js:166:28)
    at async Socket.<anonymous> (.../node_modules/ep_comments_page/index.js:89:7)
```