### PR TITLE
Properly escape html10n arguments in suggested change template

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -589,12 +589,10 @@ EpComments.prototype.insertComment = function (commentId, comment, index) {
 
   comment.commentId = commentId;
   comment.reply = true;
-  content = $('#commentsTemplate').tmpl({
-    ...comment,
-    changeArgs: JSON.stringify({
-      changeFrom: comment.changeFrom,
-      changeTo: comment.changeTo,
-    }).replace(/"/g, '&quot;'),
+  content = $('#commentsTemplate').tmpl(comment);
+  content.find('.from-label')[0].dataset.l10nArgs = JSON.stringify({
+    changeFrom: comment.changeFrom,
+    changeTo: comment.changeTo,
   });
   if (comment.author !== clientVars.userId) {
     $(content).find('.comment-actions-wrapper').addClass('hidden');

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -589,7 +589,13 @@ EpComments.prototype.insertComment = function (commentId, comment, index) {
 
   comment.commentId = commentId;
   comment.reply = true;
-  content = $('#commentsTemplate').tmpl(comment);
+  content = $('#commentsTemplate').tmpl({
+    ...comment,
+    changeArgs: JSON.stringify({
+      changeFrom: comment.changeFrom,
+      changeTo: comment.changeTo,
+    }).replace(/"/g, '&quot;'),
+  });
   if (comment.author !== clientVars.userId) {
     $(content).find('.comment-actions-wrapper').addClass('hidden');
   }

--- a/templates/comments.html
+++ b/templates/comments.html
@@ -97,10 +97,7 @@
     {{if changeTo}}
     <form class="comment-changeTo-form suggestion-display">
         <div>
-          <!-- TODO: Fix below line to properly handle escaped characters -->
-          <!-- Using escape() is a temp fix designed to handle suggestions to "foo" -->
-          <!-- which historically would break a pad :( -->
-            <span class="from-label" data-l10n-id="ep_comments_page.comments_template.suggested_change_from" data-l10n-args='{"changeFrom": "${changeFrom}", "changeTo": "${escape(changeTo)}"}'>Suggested Change From</span>
+            <span class="from-label" data-l10n-id="ep_comments_page.comments_template.suggested_change_from" data-l10n-args="${changeArgs}">Suggested Change From</span>
             <span class="hidden from-value">${changeFrom}</span>
             <span class="hidden to-value">${changeTo}</span>
         </div>

--- a/templates/comments.html
+++ b/templates/comments.html
@@ -97,7 +97,7 @@
     {{if changeTo}}
     <form class="comment-changeTo-form suggestion-display">
         <div>
-            <span class="from-label" data-l10n-id="ep_comments_page.comments_template.suggested_change_from" data-l10n-args="${changeArgs}">Suggested Change From</span>
+            <span class="from-label" data-l10n-id="ep_comments_page.comments_template.suggested_change_from">Suggested Change From</span>
             <span class="hidden from-value">${changeFrom}</span>
             <span class="hidden to-value">${changeTo}</span>
         </div>


### PR DESCRIPTION
I removed the `escape()` call and instead used `JSON.stringify` in `index.js`, so the characters will be properly escaped, and quotation marks won't screw anything up and no XSS attacks can be done. I set a `changeArgs` variable that is passed to the template. This should fix #211 and fix #175.