### PR TITLE
fixed focusing bug in new comment form

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -901,12 +901,6 @@ EpComments.prototype.displayNewCommentForm = function () {
   // Write the text to the changeFrom form
   $('#newComment').find('.from-value').text(selectedText);
 
-  // Display form
-  setTimeout(() => {
-    const position = getXYOffsetOfRep(rep);
-    newComment.showNewCommentPopup(position);
-  });
-
   // Check if the first element selected is visible in the viewport
   const $firstSelectedElement = this.getFirstElementSelected();
   const firstSelectedElementInViewport = this.isElementInViewport($firstSelectedElement);
@@ -915,8 +909,9 @@ EpComments.prototype.displayNewCommentForm = function () {
     this.scrollViewportIfSelectedTextIsNotVisible($firstSelectedElement);
   }
 
-  // Adjust focus on the form
-  $('#newComment').find('.comment-content').focus();
+  // Display form
+  const position = getXYOffsetOfRep(rep);
+  newComment.showNewCommentPopup(position);
 };
 
 EpComments.prototype.scrollViewportIfSelectedTextIsNotVisible = function ($firstSelectedElement) {

--- a/static/js/newComment.js
+++ b/static/js/newComment.js
@@ -95,6 +95,7 @@ const showNewCommentPopup = (position) => {
 
   // Show popup
   $newComment.addClass('popup-show');
+  $newComment.find('.comment-content').focus();
 
   // mark selected text, so it is clear to user which text range the comment is being applied to
   pad.plugins.ep_comments_page.preCommentMarker.markSelectedText();

--- a/static/tests/frontend/specs/newComment.js
+++ b/static/tests/frontend/specs/newComment.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const utils = require('../utils');
+
+before(async function () {
+  await utils.aNewPad();
+  helper.padInner$('div').first()
+      .sendkeys('{selectall}')
+      .sendkeys('{del}')
+      .text('commented text')
+      .sendkeys('{selectall}');
+});
+
+it('new comment button focuses on comment textarea', async function () {
+  helper.padChrome$('.addComment').click();
+  expect(helper.padChrome$.document.activeElement)
+      .to.be(helper.padChrome$('#newComment').find('.comment-content')[0]);
+});


### PR DESCRIPTION
When you add a new comment, the text field which pops up should automatically get the focus. This behaviour was expressed in the code but unfortunately not working. I believe this is due to `focus()` being called before the form is visible. By adding an interval that repeatedly tries to change the focus (until it works) with small times in between I was able to fix this problem.