### PR TITLE
🐛💄 — Show entirely substitution proposal even if it’s long

### DIFF
--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -108,6 +108,9 @@ input.error, textarea.error {
   margin-top: 5px;
   white-space: normal;
 }
+.suggestion-display .from-label {
+  line-break: anywhere;
+}
 .suggestion-display .from-label,
 .suggestion-display .to-label {
   margin-right: 2px;


### PR DESCRIPTION
Until #211 is solved, substitution proposal are considered as one long word (because spaces are replaced by `%20`), so the proposal may not be displayed entirely.

This PR adds CSS line-break to it, allowing to be able to view the entire proposal.