### PR TITLE
fix: delete comments element when displayCommentAsIcon=true

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -789,7 +789,12 @@ EpComments.prototype.getCommentData = function () {
 
 // Delete a pad comment
 EpComments.prototype.deleteComment = function (commentId) {
-  $('iframe[name="ace_outer"]').contents().find(`#${commentId}`).remove();
+  while($('iframe[name="ace_outer"]').contents().find(`#${commentId}`).length > 0){
+    $('iframe[name="ace_outer"]').contents().find(`#${commentId}`).remove();
+  }
+  while($('iframe[name="ace_outer"]').contents().find(`#icon-${commentId}`).length > 0){
+    $('iframe[name="ace_outer"]').contents().find(`#icon-${commentId}`).remove();
+  }
 };
 
 const cloneLine = (line) => {


### PR DESCRIPTION
When set diplayCommentAsIcon:true, delete the comment ,the data is deleted, but the element is still display on the page.

The reason is have two ${commentId} elements on the page.