### PR TITLE
Fix: io is not defined crash (#339)

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -19,8 +19,8 @@ const preCommentMark = require('ep_comments_page/static/js/preCommentMark');
 const getCommentIdOnFirstPositionSelected = events.getCommentIdOnFirstPositionSelected;
 const hasCommentOnSelection = events.hasCommentOnSelection;
 const Security = require('ep_etherpad-lite/static/js/security');
-// eslint-disable-next-line no-redeclare
-const io = require('socket.io-client');
+const socketIoClient = require('socket.io-client');
+const io = socketIoClient.default || socketIoClient;
 
 const cssFiles = [
   'ep_comments_page/static/css/comment.css',


### PR DESCRIPTION
## Summary

Fixes #339 — `ReferenceError: Can't find variable: io`

The `require('socket.io-client')` returns the module namespace object when bundled by esbuild, not the `io` function directly. Added `.default` fallback to handle both CJS and ESM module formats.

## Test plan

- [ ] Open a pad with comments — no error popup
- [ ] Add a comment — socket connection works
- [ ] Verify comment replies sync between users

🤖 Generated with [Claude Code](https://claude.com/claude-code)