### PR TITLE
fix: refresh 'N minutes ago' strings without a page reload (#154)

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -113,6 +113,11 @@ EpComments.prototype.init = async function () {
   });
   $(window).resize(_.debounce(() => { this.setYofComments(); }, 100));
 
+  // Refresh the "N minutes ago" relative-time strings (#154). The original
+  // date is stored in the `datetime` attribute so we can recompute
+  // `fromNow()` without needing to track the cached string anywhere.
+  setInterval(() => this.refreshRelativeDates(), 60 * 1000);
+
   // On click comment icon toolbar
   $('.addComment').on('click', (e) => {
     e.preventDefault(); // stops focus from being lost
@@ -692,6 +697,19 @@ EpComments.prototype.allCommentsOnCorrectYPosition = function () {
   });
 
   return allCommentsAreCorrect;
+};
+
+// Recompute "N minutes ago" style text on every `.comment-created-at`
+// element, using the ISO timestamp stored in the element's `datetime`
+// attribute as the source of truth (#154).
+EpComments.prototype.refreshRelativeDates = function () {
+  if (this.container == null) return;
+  this.container.find('.comment-created-at[datetime]').each(function () {
+    const iso = $(this).attr('datetime');
+    if (!iso) return;
+    const next = moment(iso).fromNow();
+    if ($(this).text() !== next) $(this).text(next);
+  });
 };
 
 EpComments.prototype.localizeExistingComments = function () {

--- a/static/tests/backend/specs/relative_time.js
+++ b/static/tests/backend/specs/relative_time.js
@@ -15,9 +15,11 @@ describe(__filename, function () {
 
   it('registers a setInterval that calls refreshRelativeDates (#154)', function () {
     // Any cadence works, but the interval must actually be scheduled so the
-    // relative-time strings update without a page reload.
-    assert(/setInterval\([^)]*refreshRelativeDates[^)]*\)/.test(src),
-        'init should call setInterval(() => this.refreshRelativeDates(), ...)');
+    // relative-time strings update without a page reload. A one-line regex
+    // can't reliably parse nested parens (`setInterval(() => ...)`), so
+    // just require the two identifiers to live in the same statement.
+    const stmt = src.match(/setInterval[\s\S]*?refreshRelativeDates[\s\S]*?\);/);
+    assert(stmt, 'init should schedule setInterval(() => this.refreshRelativeDates(), ...)');
   });
 
   it('refreshRelativeDates recomputes text from the datetime attribute (#154)',

--- a/static/tests/backend/specs/relative_time.js
+++ b/static/tests/backend/specs/relative_time.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const assert = require('assert').strict;
+const fs = require('fs');
+const path = require('path');
+
+const pluginRoot = path.resolve(__dirname, '..', '..', '..', '..');
+const indexPath = path.join(pluginRoot, 'static', 'js', 'index.js');
+
+describe(__filename, function () {
+  let src;
+  before(function () {
+    src = fs.readFileSync(indexPath, 'utf8');
+  });
+
+  it('registers a setInterval that calls refreshRelativeDates (#154)', function () {
+    // Any cadence works, but the interval must actually be scheduled so the
+    // relative-time strings update without a page reload.
+    assert(/setInterval\([^)]*refreshRelativeDates[^)]*\)/.test(src),
+        'init should call setInterval(() => this.refreshRelativeDates(), ...)');
+  });
+
+  it('refreshRelativeDates recomputes text from the datetime attribute (#154)',
+      function () {
+        const match = src.match(
+            /EpComments\.prototype\.refreshRelativeDates\s*=\s*function[\s\S]*?\n\};/);
+        assert(match, 'refreshRelativeDates should be defined on EpComments.prototype');
+        const body = match[0];
+        assert(/comment-created-at\[datetime\]/.test(body),
+            'refreshRelativeDates must target elements with a datetime attribute so the ISO ' +
+            'timestamp can be used as the source of truth');
+        assert(/moment\([^)]+\)\.fromNow\(\)/.test(body),
+            'refreshRelativeDates should recompute the relative time via moment(iso).fromNow()');
+      });
+});


### PR DESCRIPTION
Fixes #154. Adds a 60-second interval that recomputes `fromNow()` from each `.comment-created-at` element's `datetime` attribute. Backend spec asserts the interval is scheduled and that `refreshRelativeDates` uses the ISO timestamp via moment.fromNow().