### PR TITLE
fix: let links inside a comment stay clickable when displayCommentAsIcon is on (#90)

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -481,6 +481,12 @@ EpComments.prototype.collectComments = function (callback) {
     });
 
     this.padInner.contents().on('click', '.comment', function (e) {
+      // When comments are displayed as gutter icons, the user opens the
+      // comment by clicking the icon — the inline `.comment` span should
+      // behave like ordinary prose, so links inside a comment remain
+      // clickable. Previously the click handler popped up a modal
+      // intercepting the link click (#90).
+      if (clientVars.displayCommentAsIcon) return;
       const commentId = self.commentIdOf(e);
       commentBoxes.highlightComment(commentId, e, $(this));
     });


### PR DESCRIPTION
Fixes #90. With `displayCommentAsIcon: true`, the comment is opened by clicking the gutter icon — the inline `.comment` span in the pad should behave like ordinary prose so that links inside a commented selection remain clickable. The click handler was popping up the comment modal at the click position regardless, intercepting every link click. Early-return from the handler when icon mode is on; mouseover preview and icon-based open flow are untouched.