### PR TITLE
Derive socket.io path from Etherpad base URL

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -54,10 +54,16 @@ const EpComments = function (context) {
   // This probably needs some work for instances running on root or not on /p/
   const loc = document.location;
   const port = loc.port === '' ? (loc.protocol === 'https:' ? 443 : 80) : loc.port;
+
+  // Derive the socket.io path from the Etherpad base URL so that it works
+  // behind a reverse proxy with a path prefix (e.g. /etherpad/api/{group}/).
+  const pad = require('ep_etherpad-lite/static/js/pad');
+  const basePath = pad.baseURL || new URL('..', loc.href).pathname;
   const url = `${loc.protocol}//${loc.hostname}:${port}/comment`;
 
   this.padId = clientVars.padId;
   this.socket = io.connect(url, {
+    path: `${basePath}socket.io`,
     query: `padId=${this.padId}`,
   });
 


### PR DESCRIPTION
Connecting socket.io with only a host+port URL fails when Etherpad is served behind a reverse proxy with a path prefix (e.g. /etherpad/api/{group}/) because socket.io probes /socket.io by default. Read pad.baseURL (with a fallback to the URL parent of the current location) and pass it as the `path` option so the connection succeeds regardless of the deployment prefix.