### PR TITLE
Commit accept/revert change to ace via ace_fastIncorp

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -283,6 +283,12 @@ EpComments.prototype.init = async function () {
     // Write the new pad contents
     padCommentSpan.html(newString);
 
+    // Force ace to pick up the DOM change so it is committed to the
+    // changeset and propagated to other users.
+    self.ace.callWithAce((ace) => {
+      ace.ace_fastIncorp();
+    }, 'acceptOrRevertSuggestion', true);
+
     if (isRevert) {
       // Tell all users this change was reverted
       self._send('revertChange', data);


### PR DESCRIPTION
After accepting or reverting a suggested change the DOM was rewritten directly, but ace was not told to incorporate the change, so the edit only became part of the changeset (and reached other users) once the local user did something else in the pad. Call ace_fastIncorp right after writing the new pad contents to force ace to commit it.