### PR TITLE
feat: migrate to ep_plugin_helpers padToggle for User + Pad Wide settings

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -11,7 +11,8 @@
         "aceAttribsToClasses": "ep_comments_page/static/js/index",
         "aceEditorCSS": "ep_comments_page/static/js/index",
         "aceEditEvent": "ep_comments_page/static/js/index",
-        "aceInitialized": "ep_comments_page/static/js/index"
+        "aceInitialized": "ep_comments_page/static/js/index",
+        "handleClientMessage_CLIENT_MESSAGE": "ep_comments_page/static/js/index"
       },
       "hooks": {
         "padInitToolbar": "ep_comments_page/index",
@@ -23,7 +24,9 @@
         "eejsBlock_editbarMenuLeft": "ep_comments_page/index",
         "eejsBlock_scripts": "ep_comments_page/index",
         "eejsBlock_mySettings": "ep_comments_page/index",
+        "eejsBlock_padSettings": "ep_comments_page/index",
         "eejsBlock_styles": "ep_comments_page/index",
+        "loadSettings": "ep_comments_page/index",
         "clientVars": "ep_comments_page/index",
         "exportHtmlAdditionalTagsWithData": "ep_comments_page/exportHTML",
         "getLineHTMLForExport": "ep_comments_page/exportHTML",

--- a/index.js
+++ b/index.js
@@ -10,6 +10,21 @@ const apiUtils = require('./apiUtils');
 const _ = require('underscore');
 const padMessageHandler = require('ep_etherpad-lite/node/handler/PadMessageHandler');
 const readOnlyManager = require('ep_etherpad-lite/node/db/ReadOnlyManager').default || require('ep_etherpad-lite/node/db/ReadOnlyManager');
+const {padToggle} = require('ep_plugin_helpers/pad-toggle-server');
+
+// Parallel User Settings + Pad Wide Settings checkboxes for comment-pane
+// visibility. Helper owns the storage, broadcast, enforce, and i18n wiring.
+const commentsToggle = padToggle({
+  pluginName: 'ep_comments_page',
+  settingId: 'comments',
+  l10nId: 'ep_comments_page.show_comments',
+  defaultLabel: 'Show Comments',
+  defaultEnabled: true,
+});
+
+exports.loadSettings = commentsToggle.loadSettings;
+exports.eejsBlock_mySettings = commentsToggle.eejsBlock_mySettings;
+exports.eejsBlock_padSettings = commentsToggle.eejsBlock_padSettings;
 
 let io;
 
@@ -153,11 +168,6 @@ exports.eejsBlock_dd_insert = (hookName, args, cb) => {
   return cb();
 };
 
-exports.eejsBlock_mySettings = (hookName, args, cb) => {
-  args.content += eejs.require('ep_comments_page/templates/settings.ejs');
-  return cb();
-};
-
 exports.padInitToolbar = (hookName, args, cb) => {
   const toolbar = args.toolbar;
 
@@ -192,15 +202,15 @@ exports.eejsBlock_styles = (hookName, args, cb) => {
   return cb();
 };
 
-exports.clientVars = (hook, context, cb) => {
+exports.clientVars = async (hook, context) => {
   const displayCommentAsIcon =
     settings.ep_comments_page ? settings.ep_comments_page.displayCommentAsIcon : false;
   const highlightSelectedText =
     settings.ep_comments_page ? settings.ep_comments_page.highlightSelectedText : false;
-  return cb({
-    displayCommentAsIcon,
-    highlightSelectedText,
-  });
+  // Merge in the padToggle helper's clientVars block so the client-side
+  // helper can read padWideSupported/initialPadEnabled/etc.
+  const helperVars = await commentsToggle.clientVars(hook, context);
+  return Object.assign({displayCommentAsIcon, highlightSelectedText}, helperVars);
 };
 
 exports.expressCreateServer = (hookName, args, callback) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "Adds comments on sidebar and link it to the text.  For no-skin use ep_page_view.",
   "name": "ep_comments_page",
-  "version": "11.0.34",
+  "version": "11.1.0",
   "author": {
     "name": "Nicolas Lescop",
     "email": "limplementeur@gmail.com"
@@ -23,6 +23,7 @@
   ],
   "dependencies": {
     "cheerio": "^1.2.0",
+    "ep_plugin_helpers": "^0.3.0",
     "formidable": "^3.5.4",
     "underscore": "^1.13.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       cheerio:
         specifier: ^1.2.0
         version: 1.2.0
+      ep_plugin_helpers:
+        specifier: ^0.3.0
+        version: 0.3.1
       formidable:
         specifier: ^3.5.4
         version: 3.5.4
@@ -207,31 +210,37 @@ packages:
     resolution: {integrity: sha512-p+s/Wp8rf75Qqs2EPw4HC0xVLLW+/60MlVAsB7TYLoeg1e1CU/QCis36FxpziLS0ZY2+wXdTnPUxr+5kkThzwQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/rspack-resolver-binding-linux-arm64-musl@1.3.0':
     resolution: {integrity: sha512-cZEL9jmZ2kAN53MEk+fFCRJM8pRwOEboDn7sTLjZW+hL6a0/8JNfHP20n8+MBDrhyD34BSF4A6wPCj/LNhtOIQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/rspack-resolver-binding-linux-ppc64-gnu@1.3.0':
     resolution: {integrity: sha512-IOeRhcMXTNlk2oApsOozYVcOHu4t1EKYKnTz4huzdPyKNPX0Y9C7X8/6rk4aR3Inb5s4oVMT9IVKdgNXLcpGAQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/rspack-resolver-binding-linux-s390x-gnu@1.3.0':
     resolution: {integrity: sha512-op54XrlEbhgVRCxzF1pHFcLamdOmHDapwrqJ9xYRB7ZjwP/zQCKzz/uAsSaAlyQmbSi/PXV7lwfca4xkv860/Q==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/rspack-resolver-binding-linux-x64-gnu@1.3.0':
     resolution: {integrity: sha512-orbQF7sN02N/b9QF8Xp1RBO5YkfI+AYo9VZw0H2Gh4JYWSuiDHjOPEeFPDIRyWmXbQJuiVNSB+e1pZOjPPKIyg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/rspack-resolver-binding-linux-x64-musl@1.3.0':
     resolution: {integrity: sha512-kpjqjIAC9MfsjmlgmgeC8U9gZi6g/HTuCqpI7SBMjsa7/9MvBaQ6TJ7dtnsV/+DXvfJ2+L5teBBXG+XxfpvIFA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/rspack-resolver-binding-wasm32-wasi@1.3.0':
     resolution: {integrity: sha512-JAg0hY3kGsCPk7Jgh16yMTBZ6VEnoNR1DFZxiozjKwH+zSCfuDuM5S15gr50ofbwVw9drobIP2TTHdKZ15MJZQ==}
@@ -494,6 +503,10 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  ep_plugin_helpers@0.3.1:
+    resolution: {integrity: sha512-PHvLsJGJHQNLvP4R4k+D54f6JasD/uv9T4S0UaLHePjQBy0INpiS8iFXLeAY60EbgeznhMJLgE2DVy+32bZTLQ==}
+    engines: {node: '>=18.0.0'}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -1970,6 +1983,8 @@ snapshots:
   entities@6.0.1: {}
 
   entities@7.0.1: {}
+
+  ep_plugin_helpers@0.3.1: {}
 
   es-abstract@1.24.2:
     dependencies:

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -18,7 +18,11 @@ const moment = require('ep_comments_page/static/js/moment-with-locales.min');
 // read-only reference to the already-loaded module.
 if (typeof window !== 'undefined') window.__epcpMoment = moment;
 const newComment = require('ep_comments_page/static/js/newComment');
-const padcookie = require('ep_etherpad-lite/static/js/pad_cookie').padcookie;
+// Sub-path import keeps the client bundle clean. Importing the top-level
+// `ep_plugin_helpers` index pulls in every helper's getters; `settings` and
+// `toggle` reach server-only modules (eejs, Settings) which esbuild can't
+// resolve for the browser.
+const {padToggle} = require('ep_plugin_helpers/pad-toggle');
 const preCommentMark = require('ep_comments_page/static/js/preCommentMark');
 const getCommentIdOnFirstPositionSelected = events.getCommentIdOnFirstPositionSelected;
 const hasCommentOnSelection = events.hasCommentOnSelection;
@@ -30,6 +34,17 @@ const cssFiles = [
   'ep_comments_page/static/css/comment.css',
   'ep_comments_page/static/css/commentIcon.css',
 ];
+
+// Same config as the server-side instance — must agree on pluginName,
+// settingId, l10nId, and defaultLabel for the checkbox ids and clientVars
+// lookup to line up.
+const commentsToggle = padToggle({
+  pluginName: 'ep_comments_page',
+  settingId: 'comments',
+  l10nId: 'ep_comments_page.show_comments',
+  defaultLabel: 'Show Comments',
+  defaultEnabled: true,
+});
 
 const UPDATE_COMMENT_LINE_POSITION_EVENT = 'updateCommentLinePosition';
 
@@ -358,25 +373,15 @@ EpComments.prototype.init = async function () {
   });
 
 
-  // Enable and handle cookies
-  if (padcookie.getPref('comments') === false) {
-    this.padOuter.find('#comments, #commentIcons').removeClass('active');
-    $('#options-comments').prop('checked', false);
-    $('#options-comments').prop('checked', false);
-  } else {
-    $('#options-comments').prop('checked', true);
-  }
-
-  $('#options-comments').on('change', () => {
-    const checked = $('#options-comments').is(':checked');
-    padcookie.setPref('comments', checked);
+  // Wire up parallel User Settings + Pad Wide Settings checkboxes. Helper
+  // owns cookie persistence, broadcast sync, and enforce; we just react to
+  // the resolved effective value.
+  const applyVisibility = (checked) => {
     this.padOuter.find('#comments, #commentIcons').toggleClass('active', checked);
     $('body').toggleClass('comments-active', checked);
     $('iframe[name="ace_outer"]').contents().find('body').toggleClass('comments-active', checked);
-  });
-
-  // Check to see if we should show already..
-  $('#options-comments').trigger('change');
+  };
+  commentsToggle.init({onChange: applyVisibility});
 
   // Override copy, cut, paste events so that the comment class is preserved.
   // Chrome doesn't copy classes when only the inner span of a comment is
@@ -1362,6 +1367,9 @@ exports.postAceInit = hooks.postAceInit;
 exports.postToolbarInit = hooks.postToolbarInit;
 exports.aceAttribsToClasses = hooks.aceAttribsToClasses;
 exports.aceEditEvent = hooks.aceEditEvent;
+// Re-export so the helper sees pad-wide broadcasts and refreshes our state
+// when another user toggles the pad-wide checkbox.
+exports.handleClientMessage_CLIENT_MESSAGE = commentsToggle.handleClientMessage_CLIENT_MESSAGE;
 
 // Given a CSS selector and a target element (in this case pad inner)
 // return the rep as an array of array of tuples IE [[[0,1],[0,2]], [[1,3],[1,5]]]

--- a/templates/settings.ejs
+++ b/templates/settings.ejs
@@ -1,4 +1,0 @@
-<p>
-  <input type="checkbox" id="options-comments" checked></input>
-  <label for="options-comments" data-l10n-id="ep_comments_page.show_comments">Show Comments</label>
-</p>


### PR DESCRIPTION
## Summary

- Migrate the hand-rolled "Show Comments" User Settings checkbox to `ep_plugin_helpers` `padToggle` so the same toggle now appears in **both** the User Settings panel and the Pad Wide Settings panel — matching how native Etherpad toggles (sticky chat, line numbers, etc.) work.
- Pad-wide value rides Etherpad's existing `padoptions` COLLABROOM rail (broadcast to every connected client, persisted, honored by `enforceSettings`).
- The helper owns checkbox rendering, cookie persistence, broadcast sync, enforce, and i18n. The hand-rolled `templates/settings.ejs`, manual click wiring, and direct `padcookie` plumbing are gone.

## Compatibility

- Depends on `ep_plugin_helpers` ^0.3.0 (already published to npm).
- Pad Wide Settings column lights up once etherpad-lite ether/etherpad#7698 lands; until then, capability detection makes the pad-wide block a no-op and the plugin renders only User Settings — same UX as today, no regression.

## Changes

- `index.js` — register `padToggle` server hooks (`loadSettings`, `eejsBlock_mySettings`, `eejsBlock_padSettings`); merge helper's `clientVars` into existing `clientVars` so `displayCommentAsIcon` / `highlightSelectedText` and the helper's `ep_plugin_helpers.padToggle.ep_comments_page` block both ship to the client.
- `static/js/index.js` — replace the `padcookie.getPref('comments')` + manual `#options-comments` change handler with `commentsToggle.init({onChange: applyVisibility})`. Re-export `handleClientMessage_CLIENT_MESSAGE` so the helper refreshes when another user toggles the pad-wide checkbox.
- `ep.json` — register `loadSettings`, `eejsBlock_padSettings`, and `client_hooks.handleClientMessage_CLIENT_MESSAGE`.
- `package.json` — add `"ep_plugin_helpers": "^0.3.0"` dep, bump `11.0.30 → 11.1.0`.
- `templates/settings.ejs` — deleted (only contained the migrated `<input>+<label>`).

Sub-path imports used per the helper's docs: server `ep_plugin_helpers/pad-toggle-server`, client `ep_plugin_helpers/pad-toggle`. Importing the top-level `ep_plugin_helpers` from client code drags `settings`/`toggle` (which reach `eejs`/`Settings`) into the esbuild bundle and breaks it.

## Test plan

- [ ] CI backend tests pass (`l10n.js`, `padCopy.js`, `padRemove.js`, `readOnlyPad.js`, `relative_time.js`).
- [ ] CI frontend tests pass.
- [ ] On a patched Etherpad core (>= 2.7.4): both checkboxes render, toggling User Settings persists per-user via cookie, toggling Pad Wide Settings broadcasts to all clients and is honored by `enforceSettings`.
- [ ] On an un-patched core: only User Settings renders; cookie toggle behaves identically to before this PR.
- [ ] Comments pane shows/hides via the resolved effective value on initial load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)