### PR TITLE
a11y: drop redundant hardcoded aria-label

### DIFF
--- a/templates/commentBarButtons.ejs
+++ b/templates/commentBarButtons.ejs
@@ -1,6 +1,6 @@
 <li class="separator"></li>
 <li class="addComment">
-    <a title="Add new comment on selection" aria-label="Add new comment on selection" data-l10n-id="ep_comments_page.add_comment.title">
+    <a title="Add new comment on selection" data-l10n-id="ep_comments_page.add_comment.title">
       <span class="buttonicon buttonicon-comment-medical"></span>
     </a>
 </li>


### PR DESCRIPTION
## Summary

Removes hardcoded `aria-label="…"` attributes from elements that already declare `data-l10n-id`. With `aria-label` set in the template, etherpad's html10n skips the auto-population path (`html10n.ts:665-678`) and leaves screen readers with the English label even when the user's UI language is something else.

After this PR, html10n populates `aria-label` from the localized translation on every `pad.applyLanguage()` call, marked with `data-l10n-aria-label="true"` so subsequent passes refresh it.

Also drops the `data-l10n-attr="aria-label"` attribute where present — that's a convention from a different localization library (e.g. fluent-dom), and etherpad's html10n does not read it. The auto-population in lines 665-678 is the etherpad mechanism.

Part of the fleet-wide plugin a11y/i18n sweep (Phase 3 of the modernization campaign; pilot: ether/ep_align#182).