### PR TITLE
refactor: adopt template helper for 2 simple eejsBlock_* hook(s)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const {template} = require('ep_plugin_helpers');
+
 const AttributePool = require('ep_etherpad-lite/static/js/AttributePool').default || require('ep_etherpad-lite/static/js/AttributePool');
 const Changeset = require('ep_etherpad-lite/static/js/Changeset').default || require('ep_etherpad-lite/static/js/Changeset');
 const eejs = require('ep_etherpad-lite/node/eejs/');
@@ -163,10 +165,8 @@ exports.socketio = (hookName, args, cb) => {
   return cb();
 };
 
-exports.eejsBlock_dd_insert = (hookName, args, cb) => {
-  args.content += eejs.require('ep_comments_page/templates/menuButtons.ejs');
-  return cb();
-};
+exports.eejsBlock_dd_insert =
+    template('ep_comments_page/templates/menuButtons.ejs');
 
 exports.padInitToolbar = (hookName, args, cb) => {
   const toolbar = args.toolbar;
@@ -197,10 +197,8 @@ exports.eejsBlock_scripts = (hookName, args, cb) => {
   return cb();
 };
 
-exports.eejsBlock_styles = (hookName, args, cb) => {
-  args.content += eejs.require('ep_comments_page/templates/styles.html');
-  return cb();
-};
+exports.eejsBlock_styles =
+    template('ep_comments_page/templates/styles.html');
 
 exports.clientVars = async (hook, context) => {
   const displayCommentAsIcon =


### PR DESCRIPTION
## Summary

Adopts the `template()` helper from `ep_plugin_helpers` for 2 `eejsBlock_*` hook(s) that match the strict-simple shape:

```js
exports.eejsBlock_X = (hookName, args, cb) => {
  args.content += eejs.require('plugin/template.ejs');
  cb();
};
```

Replaced with:

```js
exports.eejsBlock_X = template('plugin/template.ejs');
```

Same runtime behavior — eejs renders the same template into the same section. The helper just removes per-plugin re-implementation of the `args.content += eejs.require(...)` boilerplate.

## Out of scope

Hooks with vars, conditional skip logic, or non-eejs content (e.g. raw `<script>` tags being concatenated) are left alone — those need either the helper's `vars`/`skip` callbacks or different helper variants. Part of Phase 4 of the modernization campaign (pilot: ether/ep_align#182, ether/ep_themes#103).