### PR TITLE
chore: bump engines.node to >=22 and add explicit Node 22/24/26 matrix

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -11,8 +11,23 @@ jobs:
     if: |
       (github.event_name != 'pull_request')
       || (github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id)
-    name: with Plugins
+    name: with Plugins (Node ${{ matrix.node }} / core ${{ matrix.core_ref || 'develop' }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # Plugin floor is engines.node >=22 but current Etherpad core
+      # requires >=24 (engineStrict). Each cell pairs a Node version
+      # with a core ref that actually allows it: Node 22 against the
+      # last tag whose core floor was 22 (v2.7.3); Node 24 / 26 against
+      # current develop.
+      matrix:
+        include:
+          - node: '22'
+            core_ref: 'v2.7.3'
+          - node: '24'
+            core_ref: ''
+          - node: '26'
+            core_ref: ''
     steps:
       -
         name: Install libreoffice
@@ -25,11 +40,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: ether/etherpad-lite
+          ref: ${{ matrix.core_ref }}
           path: etherpad-lite
       - uses: actions/setup-node@v6
         name: Install Node.js
         with:
-          node-version: 25
+          node-version: ${{ matrix.node }}
       - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -8,6 +8,22 @@ on:
 jobs:
   test-frontend:
     runs-on: ubuntu-latest
+    name: Playwright (Node ${{ matrix.node }} / core ${{ matrix.core_ref || 'develop' }})
+    strategy:
+      fail-fast: false
+      # Plugin floor is engines.node >=22 but current Etherpad core
+      # requires >=24 (engineStrict). Each cell pairs a Node version
+      # with a core ref that actually allows it: Node 22 against the
+      # last tag whose core floor was 22 (v2.7.3); Node 24 / 26 against
+      # current develop.
+      matrix:
+        include:
+          - node: '22'
+            core_ref: 'v2.7.3'
+          - node: '24'
+            core_ref: ''
+          - node: '26'
+            core_ref: ''
 
     steps:
       -
@@ -15,11 +31,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: ether/etherpad-lite
+          ref: ${{ matrix.core_ref }}
           path: etherpad-lite
       - uses: actions/setup-node@v6
         name: Install Node.js
         with:
-          node-version: 25
+          node-version: ${{ matrix.node }}
       - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lint:fix": "eslint --fix ."
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Pilot of the post-[ether/etherpad#7781](https://github.com/ether/etherpad/pull/7781) plugin policy: `engines.node` floats on `>=22.0.0`, decoupled from core's floor.

### Why
- Node 18 and Node 20 both hit EOL in April 2026, so dropping the previous `>=18.0.0` floor drops zero supported install audience.
- The plugin's CI was pinned at a single Node major (most recently `25`, itself EOL since Apr 10 2026). That gave us almost no signal on whether the plugin still works across the actual supported Node range.

### Changes
1. `package.json`: `engines.node` `>=18.0.0` -> `>=22.0.0`.
2. `.github/workflows/backend-tests.yml` and `.github/workflows/frontend-tests.yml`: replace the single `node-version: 25` pin with an explicit `[22, 24, 26]` matrix, with each cell paired to an Etherpad core ref that actually allows that Node:
   - `Node 22` against `v2.7.3` (last core tag whose engines.node floor was `22.13.0`).
   - `Node 24` against current `develop` (post-#7781 Node 24 floor).
   - `Node 26` against current `develop` (forward-compatibility check).

   `fail-fast: false` so a single bad cell does not mask the others.

### Local empirical verification (done before opening this PR)
| Setup | Result |
|---|---|
| **Node 22.22.3** + Etherpad **v2.7.3** + ep_comments_page **11.1.9** | Plugin loaded, pad HTTP 200, 28 plugin DOM hits (templates + toolbar icon), 0 ERROR/FATAL/WARN lines |
| **Node 24.14.0** + Etherpad **develop** (post-#7781) + ep_comments_page **11.1.9** | Plugin loaded, pad HTTP 200, 25 plugin DOM hits, 0 ERROR/FATAL/WARN lines |

So the plugin code is healthy on both ends of the declared range; no sign of the historical Node-22-related crash reports.

## Test plan
- [ ] CI \`with Plugins (Node 22 / core v2.7.3)\` passes.
- [ ] CI \`with Plugins (Node 24 / core develop)\` passes.
- [ ] CI \`with Plugins (Node 26 / core develop)\` passes.
- [ ] Same three cells pass on the frontend Playwright workflow.
- [ ] No \`ERR_PNPM_UNSUPPORTED_ENGINE\` install failures in any cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)