### PR TITLE
ci(frontend): disable updater poll so v2.7.x version-badge doesn't block chat clicks

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -69,6 +69,19 @@ jobs:
       - name: Create settings.json
         working-directory: ./etherpad-lite
         run: cp ./src/tests/settings.json settings.json
+      # Etherpad v2.7.x added a "severely outdated" version-badge that polls
+      # GitHub for the latest release and renders an absolutely-positioned
+      # banner at top-right when the running core is a full major behind.
+      # Now that 3.x is tagged on GitHub, this matrix cell (core v2.7.3)
+      # sees latest=3.x, paints the banner, and the banner intercepts
+      # pointer events on #chaticon — every chat-related Playwright test
+      # times out. Set updates.tier=off so /api/version-status is never
+      # registered and the badge stays hidden. Harmless no-op on cores
+      # without the updater (older tags, develop with tier already off).
+      - name: Disable updater poll in test settings
+        working-directory: ./etherpad-lite
+        run: |
+          node -e 'const fs=require("fs");const s=JSON.parse(fs.readFileSync("settings.json","utf8"));s.updates={...(s.updates||{}),tier:"off"};fs.writeFileSync("settings.json",JSON.stringify(s,null,2));'
       - name: Run the frontend tests
         working-directory: ./etherpad-lite
         shell: bash


### PR DESCRIPTION
## Symptom
Every chat-related Playwright spec on the `Node 22 / core v2.7.3` cell times out (`a11y_dialogs.spec.ts:105`, `chat.spec.ts:*`, `change_user_*.spec.ts:*`, `userlist_click_to_chat.spec.ts:*`). Playwright reports:

> `<div role="status" id="version-badge" aria-live="polite" data-level="severe">Etherpad on this server is severely outdated. Tel…</div> intercepts pointer events`

This started today (2026-05-17) and was triggered by an external event: v3.0.0 and v3.1.0 of Etherpad were tagged on GitHub.

## Root cause chain
1. v2.7.x added a "severely outdated" version-badge (`src/static/js/pad_version_badge.ts` + `/api/version-status` in `node/hooks/express/updateStatus.ts`).
2. The badge polls GitHub for the latest release and renders an absolutely-positioned banner at top-right when `isMajorBehind(current, latest)` (`l.major - c.major >= 1`).
3. v2.7.3's `src/tests/settings.json` doesn't override `updates`, so `updates.tier` falls back to `"notify"` — the poll runs.
4. Latest GitHub release used to be 2.7.3 itself → badge silent → ep_comments_page main last green 2026-05-16.
5. After 3.x was tagged, v2.7.3 sees latest=3.1.0, paints the badge, and it occludes `#chaticon`.

`Node 24 / core develop` and `Node 26 / core develop` are unaffected — current matches latest.

## Fix
Add a step in `frontend-tests.yml` after `cp ./src/tests/settings.json settings.json` that injects `updates.tier = "off"` into the test settings. `expressCreateServer` in `updateStatus.ts:65` short-circuits on `"off"` and never registers `/api/version-status`, so the client request 404s and the badge stays hidden.

Safe for cores without the updater feature (older tags, current develop with tier already off) — it's a benign merge of an existing key.

## Alternative considered
Upstream fix in etherpad-lite to suppress the badge in test environments (e.g. when `settings.exposeVersion === false`) is the proper long-term fix and would protect any future plugin from adding a `core ${old-tag}` matrix cell. Not in scope for this PR — file a separate issue if interested.

## Test plan
- [ ] CI green on all three matrix cells (Node 22/v2.7.3, Node 24/develop, Node 26/develop)
- [ ] No new failures introduced on the Node 24 / 26 cells (which were already green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)