### PR TITLE
fix: backward-compat for ESM etherpad

### DIFF
--- a/commentManager.js
+++ b/commentManager.js
@@ -2,11 +2,11 @@
 
 const _ = require('underscore');
 const db = require('ep_etherpad-lite/node/db/DB');
-const log4js = require('ep_etherpad-lite/node_modules/log4js');
+const {createLogger} = require('ep_plugin_helpers/logger');
 const randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
 const shared = require('./static/js/shared');
 
-const logger = log4js.getLogger('ep_comments_page');
+const logger = createLogger('ep_comments_page');
 
 exports.getComments = async (padId) => {
   // Not sure if we will encouter race conditions here..  Be careful.

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const {template} = require('ep_plugin_helpers');
 
 const AttributePool = require('ep_etherpad-lite/static/js/AttributePool').default || require('ep_etherpad-lite/static/js/AttributePool');
 const Changeset = require('ep_etherpad-lite/static/js/Changeset').default || require('ep_etherpad-lite/static/js/Changeset');
-const eejs = require('ep_etherpad-lite/node/eejs/');
+const eejs = require('ep_etherpad-lite/node/eejs');
 const settings = require('ep_etherpad-lite/node/utils/Settings');
 const {Formidable} = require('formidable');
 const commentManager = require('./commentManager');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "Adds comments on sidebar and link it to the text.  For no-skin use ep_page_view.",
   "name": "ep_comments_page",
-  "version": "11.1.14",
+  "version": "11.1.15",
   "author": {
     "name": "Nicolas Lescop",
     "email": "limplementeur@gmail.com"
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "cheerio": "^1.2.0",
-    "ep_plugin_helpers": "^0.6.0",
+    "ep_plugin_helpers": "^0.6.7",
     "formidable": "^3.5.4",
     "underscore": "^1.13.8"
   },


### PR DESCRIPTION
This PR makes the plugin backward-compatible with the upcoming ESM etherpad branch (ether/etherpad#7605).

**Changes:**
1. Remove trailing slash from `require("ep_etherpad-lite/node/eejs/")` → `require("ep_etherpad-lite/node/eejs")` (in `index.js`)
2. Migrate log4js from `require("ep_etherpad-lite/node_modules/log4js")` to `ep_plugin_helpers/logger` (in `commentManager.js`)

Both changes are **backward-compatible** with the current CJS etherpad release.