### PR TITLE
fix: hide the add-comment button on read-only pads (closes #204)

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,7 +174,9 @@ exports.padInitToolbar = (hookName, args, cb) => {
   const button = toolbar.button({
     command: 'addComment',
     localizationId: 'ep_comments_page.add_comment.title',
-    class: 'buttonicon buttonicon-comment-medical',
+    // `acl-write` lets Etherpad core hide the button on read-only pads
+    // (`.readonly .acl-write { display: none }`) — see issue #204.
+    class: 'buttonicon buttonicon-comment-medical acl-write',
   });
 
   toolbar.registerButton('addComment', button);

--- a/static/tests/frontend-new/specs/readonlyButton.spec.ts
+++ b/static/tests/frontend-new/specs/readonlyButton.spec.ts
@@ -1,0 +1,26 @@
+import {expect, test} from '@playwright/test';
+import {aNewCommentsPad} from '../helper/comments';
+
+// Issue #204: the "Add comment" toolbar button must not appear on read-only
+// pads. Marking it `acl-write` lets Etherpad core hide it via its existing
+// `.readonly .acl-write { display: none }` rule (present on every supported
+// core, so this works on the latest release and on develop).
+test.describe('ep_comments_page - read-only', () => {
+  test('the add-comment button is hidden on read-only pads (#204)', async ({page}) => {
+    await aNewCommentsPad(page);
+
+    // Visible on the writable pad.
+    await expect(page.locator('.addComment')).toBeVisible();
+
+    const readOnlyId: string = await page.evaluate(() => (window as any).clientVars.readOnlyId);
+    expect(readOnlyId).toMatch(/^r\./);
+
+    // Open the read-only view of the same pad. (Don't use the goToPad helper —
+    // its waitForEditorReady never settles on a read-only pad.)
+    await page.goto(`http://localhost:9001/p/${readOnlyId}`);
+    await page.locator('iframe[name="ace_outer"]').waitFor({timeout: 30_000});
+
+    await expect(page.locator('body')).toHaveClass(/readonly/);
+    await expect(page.locator('.addComment')).toBeHidden();
+  });
+});

--- a/static/tests/frontend-new/specs/readonlyButton.spec.ts
+++ b/static/tests/frontend-new/specs/readonlyButton.spec.ts
@@ -16,8 +16,10 @@ test.describe('ep_comments_page - read-only', () => {
     expect(readOnlyId).toMatch(/^r\./);
 
     // Open the read-only view of the same pad. (Don't use the goToPad helper —
-    // its waitForEditorReady never settles on a read-only pad.)
-    await page.goto(`http://localhost:9001/p/${readOnlyId}`);
+    // its waitForEditorReady never settles on a read-only pad.) Navigate
+    // relative to the current origin so the spec is independent of the
+    // configured baseURL / host:port.
+    await page.goto(new URL(`/p/${readOnlyId}`, page.url()).toString());
     await page.locator('iframe[name="ace_outer"]').waitFor({timeout: 30_000});
 
     await expect(page.locator('body')).toHaveClass(/readonly/);

--- a/templates/commentBarButtons.ejs
+++ b/templates/commentBarButtons.ejs
@@ -1,5 +1,5 @@
-<li class="separator"></li>
-<li class="addComment">
+<li class="separator acl-write"></li>
+<li class="addComment acl-write">
     <a title="Add new comment on selection" data-l10n-id="ep_comments_page.add_comment.title">
       <span class="buttonicon buttonicon-comment-medical"></span>
     </a>


### PR DESCRIPTION
Closes #204.

On read-only pads the **Add comment** toolbar button was still shown even though it does nothing there.

## Fix
Mark the button `acl-write`, so Etherpad core hides it via its existing `.readonly .acl-write { display: none }` rule (present on the latest release and on develop — no core change needed). Applied to both the eejs button and the `toolbar.button()` path.

## Test
`static/tests/frontend-new/specs/readonlyButton.spec.ts`: the button is visible on the writable pad and hidden on the read-only view of the same pad. Verified on the latest release (2.7.3) and develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)