### PR TITLE
refactor: remove underscore dependency (#263)

### DIFF
--- a/commentManager.js
+++ b/commentManager.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('underscore');
 const db = require('ep_etherpad-lite/node/db/DB');
 const {createLogger} = require('ep_plugin_helpers/logger');
 const randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
@@ -78,7 +77,8 @@ exports.copyComments = async (originalPadId, newPadID) => {
   // get the comments of original pad
   const originalComments = await db.get(`comments:${originalPadId}`);
   // make sure we have different copies of the comment between pads
-  const copiedComments = _.mapObject(originalComments, (thisComment) => _.clone(thisComment));
+  const copiedComments = Object.fromEntries(
+      Object.entries(originalComments || {}).map(([id, comment]) => [id, {...comment}]));
 
   // save the comments on new pad
   await db.set(`comments:${newPadID}`, copiedComments);
@@ -141,7 +141,8 @@ exports.copyCommentReplies = async (originalPadId, newPadID) => {
   // get the replies of original pad
   const originalReplies = await db.get(`comment-replies:${originalPadId}`);
   // make sure we have different copies of the reply between pads
-  const copiedReplies = _.mapObject(originalReplies, (thisReply) => _.clone(thisReply));
+  const copiedReplies = Object.fromEntries(
+      Object.entries(originalReplies || {}).map(([id, reply]) => [id, {...reply}]));
 
   // save the comment replies on new pad
   await db.set(`comment-replies:${newPadID}`, copiedReplies);

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ const settings = require('ep_etherpad-lite/node/utils/Settings');
 const {Formidable} = require('formidable');
 const commentManager = require('./commentManager');
 const apiUtils = require('./apiUtils');
-const _ = require('underscore');
 const padMessageHandler = require('ep_etherpad-lite/node/handler/PadMessageHandler');
 const readOnlyManager = require('ep_etherpad-lite/node/db/ReadOnlyManager').default || require('ep_etherpad-lite/node/db/ReadOnlyManager');
 const {padToggle} = require('ep_plugin_helpers/pad-toggle-server');
@@ -137,14 +136,15 @@ exports.socketio = (hookName, args, cb) => {
       padId = (await readOnlyManager.getIds(padId)).padId;
       const [commentIds, comments] = await commentManager.bulkAddComments(padId, data);
       socket.broadcast.to(padId).emit('pushAddCommentInBulk');
-      return _.object(commentIds, comments); // {c-123:data, c-124:data}
+      // {c-123:data, c-124:data}
+      return Object.fromEntries(commentIds.map((id, i) => [id, comments[i]]));
     }));
 
     socket.on('bulkAddCommentReplies', handler(async (padId, data) => {
       padId = (await readOnlyManager.getIds(padId)).padId;
       const [repliesId, replies] = await commentManager.bulkAddCommentReplies(padId, data);
       socket.broadcast.to(padId).emit('pushAddCommentReply', repliesId, replies);
-      return _.zip(repliesId, replies);
+      return repliesId.map((id, i) => [id, replies[i]]);
     }));
 
     socket.on('updateCommentText', handler(async (data) => {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   "dependencies": {
     "cheerio": "^1.2.0",
     "ep_plugin_helpers": "^0.6.7",
-    "formidable": "^3.5.4",
-    "underscore": "^1.13.8"
+    "formidable": "^3.5.4"
   },
   "devDependencies": {
     "eslint": "^8.57.1",

--- a/static/js/copyPasteEvents.js
+++ b/static/js/copyPasteEvents.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('underscore');
 const randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
 const shared = require('./shared');
 
@@ -49,15 +48,15 @@ exports.addTextOnClipboard = (e, ace, padInner, removeSelection, comments, repli
 
 const getReplyData = (replies, commentIds) => {
   let replyData = {};
-  _.each(commentIds, (commentId) => {
-    replyData = _.extend(getRepliesFromCommentId(replies, commentId), replyData);
+  commentIds.forEach((commentId) => {
+    replyData = Object.assign(getRepliesFromCommentId(replies, commentId), replyData);
   });
   return replyData;
 };
 
 const getRepliesFromCommentId = (replies, commentId) => {
   const repliesFromCommentID = {};
-  _.each(replies, (reply, replyId) => {
+  Object.entries(replies || {}).forEach(([replyId, reply]) => {
     if (reply.commentId === commentId) {
       repliesFromCommentID[replyId] = reply;
     }
@@ -67,7 +66,7 @@ const getRepliesFromCommentId = (replies, commentId) => {
 
 const buildCommentIdToFakeIdMap = (commentsData) => {
   const commentIdToFakeId = {};
-  _.each(commentsData, (comment, fakeCommentId) => {
+  Object.entries(commentsData).forEach(([fakeCommentId, comment]) => {
     const commentId = comment.data.originalCommentId;
     commentIdToFakeId[commentId] = fakeCommentId;
   });
@@ -76,7 +75,7 @@ const buildCommentIdToFakeIdMap = (commentsData) => {
 
 const replaceCommentIdsWithFakeIds = (commentsData, html) => {
   const commentIdToFakeId = buildCommentIdToFakeIdMap(commentsData);
-  _.each(commentIdToFakeId, (fakeCommentId, commentId) => {
+  Object.entries(commentIdToFakeId).forEach(([commentId, fakeCommentId]) => {
     $(html).find(`.${commentId}`).removeClass(commentId).addClass(fakeCommentId);
   });
   const htmlWithFakeCommentIds = getHtml(html);
@@ -86,7 +85,7 @@ const replaceCommentIdsWithFakeIds = (commentsData, html) => {
 const buildCommentsData = (html, comments) => {
   const commentsData = {};
   const originalCommentIds = getCommentIds(html);
-  _.each(originalCommentIds, (originalCommentId) => {
+  originalCommentIds.forEach((originalCommentId) => {
     const fakeCommentId = generateFakeCommentId();
     const comment = comments[originalCommentId];
     comment.data.originalCommentId = originalCommentId;
@@ -101,9 +100,9 @@ const generateFakeCommentId = () => {
 };
 
 const getCommentIds = (html) => {
-  const allSpans = $(html).find('span');
+  const allSpans = $(html).find('span').toArray();
   const commentIds = [];
-  _.each(allSpans, (span) => {
+  allSpans.forEach((span) => {
     const cls = $(span).attr('class');
     const classCommentId = /(?:^| )(c-[A-Za-z0-9]*)/.exec(cls);
     const commentId = (classCommentId) ? classCommentId[1] : false;
@@ -217,7 +216,7 @@ const saveComments = (comments) => {
   const mapOriginalCommentsId = pad.plugins.ep_comments_page.mapOriginalCommentsId;
   const mapFakeComments = pad.plugins.ep_comments_page.mapFakeComments;
 
-  _.each(comments, (comment, fakeCommentId) => {
+  Object.entries(comments).forEach(([fakeCommentId, comment]) => {
     const newCommentId = shared.generateCommentId();
     mapFakeComments[fakeCommentId] = newCommentId;
     const originalCommentId = comment.data.originalCommentId;
@@ -231,7 +230,7 @@ const saveReplies = (replies) => {
   const repliesToSave = {};
   const padId = clientVars.padId;
   const mapOriginalCommentsId = pad.plugins.ep_comments_page.mapOriginalCommentsId;
-  _.each(replies, (reply, replyId) => {
+  Object.entries(replies).forEach(([replyId, reply]) => {
     const originalCommentId = reply.commentId;
     // as the comment copied has got a new commentId, we set this id in the reply as well
     reply.commentId = mapOriginalCommentsId[originalCommentId];
@@ -258,7 +257,7 @@ const htmlDecode = (input) => {
 exports.getCommentIdOnFirstPositionSelected = function () {
   const attributeManager = this.documentAttributeManager;
   const rep = this.rep;
-  const commentId = _.object(
+  const commentId = Object.fromEntries(
       attributeManager.getAttributesOnPosition(rep.selStart[0], rep.selStart[1])).comment;
   return commentId;
 };
@@ -311,7 +310,7 @@ const hasCommentOnLine = (lineNumber, firstColumn, lastColumn, attributeManager)
   let foundCommentOnLine = false;
   for (let column = firstColumn; column <= lastColumn && !foundCommentOnLine; column++) {
     const commentId =
-      _.object(attributeManager.getAttributesOnPosition(lineNumber, column)).comment;
+      Object.fromEntries(attributeManager.getAttributesOnPosition(lineNumber, column)).comment;
     if (commentId !== undefined) {
       foundCommentOnLine = true;
     }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -6,7 +6,6 @@
 */
 
 
-const _ = require('underscore');
 const commentBoxes = require('ep_comments_page/static/js/commentBoxes');
 const commentIcons = require('ep_comments_page/static/js/commentIcons');
 const commentL10n = require('ep_comments_page/static/js/commentL10n');
@@ -29,6 +28,15 @@ const hasCommentOnSelection = events.hasCommentOnSelection;
 const Security = require('ep_etherpad-lite/static/js/security');
 const socketIoClient = require('socket.io-client');
 const io = socketIoClient.default || socketIoClient;
+
+// Trailing-edge debounce (replaces the former underscore dependency, #263).
+const debounce = (fn, wait) => {
+  let timeout;
+  return function (...args) {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn.apply(this, args), wait);
+  };
+};
 
 const cssFiles = [
   'ep_comments_page/static/css/comment.css',
@@ -136,7 +144,7 @@ EpComments.prototype.init = async function () {
   this.padInner.contents().on(UPDATE_COMMENT_LINE_POSITION_EVENT, (e) => {
     this.setYofComments();
   });
-  $(window).resize(_.debounce(() => { this.setYofComments(); }, 100));
+  $(window).resize(debounce(() => { this.setYofComments(); }, 100));
 
   // Refresh the "N minutes ago" relative-time strings (#154). The original
   // date is stored in the `datetime` attribute so we can recompute
@@ -676,7 +684,7 @@ EpComments.prototype.setYofComments = function () {
   });
 
   // re-display comments that were visible before
-  _.each(commentsToBeShown, (commentEle) => {
+  commentsToBeShown.forEach((commentEle) => {
     commentEle.show();
   });
 };
@@ -686,13 +694,13 @@ EpComments.prototype.getFirstOcurrenceOfCommentIds = function () {
   const padInner = padOuter.find('iframe[name="ace_inner"]').contents();
   const commentsId = this.getUniqueCommentsId(padInner);
   const firstOcurrenceOfCommentIds =
-    _.map(commentsId, (commentId) => padInner.find(`.${commentId}`).first().get(0));
+    commentsId.map((commentId) => padInner.find(`.${commentId}`).first().get(0));
   return firstOcurrenceOfCommentIds;
 };
 
 EpComments.prototype.getUniqueCommentsId = function (padInner) {
-  const inlineComments = padInner.find('.comment');
-  const commentsId = _.map(inlineComments, (inlineComment) => {
+  const inlineComments = padInner.find('.comment').toArray();
+  const commentsId = inlineComments.map((inlineComment) => {
     const commentId = /(?:^| )(c-[A-Za-z0-9]*)/.exec(inlineComment.className);
     // avoid when it has a '.comment' that it has a fakeComment class 'fakecomment-123' yet.
     if (commentId && commentId[1]) return commentId[1];
@@ -892,7 +900,7 @@ const getXYOffsetOfRep = (rep) => {
   // make sure end is after start
   if (selStart[0] > selEnd[0] || (selStart[0] === selEnd[0] && selStart[1] > selEnd[1])) {
     selEnd = selStart;
-    selStart = _.clone(selStart);
+    selStart = [...selStart];
   }
 
   let startIndex = 0;
@@ -1136,8 +1144,8 @@ EpComments.prototype.saveCommentWithoutSelection = async function (padId, commen
 };
 
 EpComments.prototype.buildComments = function (commentsData) {
-  const comments =
-    _.map(commentsData, (commentData, commentId) => this.buildComment(commentId, commentData.data));
+  const comments = Object.entries(commentsData).map(
+      ([commentId, commentData]) => this.buildComment(commentId, commentData.data));
   return comments;
 };
 
@@ -1163,14 +1171,14 @@ EpComments.prototype.getMapfakeComments = function () {
 EpComments.prototype.saveCommentReplies = async function (padId, commentReplyData) {
   const data = this.buildCommentReplies(commentReplyData);
   const replies = await this._send('bulkAddCommentReplies', padId, data);
-  _.each(replies, (reply) => {
+  (replies || []).forEach((reply) => {
     this.setCommentReply(reply);
   });
   this.shouldCollectComment = true; // force collect the comment replies saved
 };
 
 EpComments.prototype.buildCommentReplies = function (repliesData) {
-  const replies = _.map(repliesData, (replyData) => this.buildCommentReply(replyData));
+  const replies = Object.values(repliesData).map((replyData) => this.buildCommentReply(replyData));
   return replies;
 };
 
@@ -1199,7 +1207,7 @@ EpComments.prototype.commentListen = function () {
       // but it's expected to be {c-123: {data: {author:...}}, c-124:{data:{author:...}}}
       // in this.comments
       const commentsProcessed = {};
-      _.map(allComments, (comment, commentId) => {
+      Object.entries(allComments).forEach(([commentId, comment]) => {
         commentsProcessed[commentId] = {};
         commentsProcessed[commentId].data = comment;
       });

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1171,7 +1171,10 @@ EpComments.prototype.getMapfakeComments = function () {
 EpComments.prototype.saveCommentReplies = async function (padId, commentReplyData) {
   const data = this.buildCommentReplies(commentReplyData);
   const replies = await this._send('bulkAddCommentReplies', padId, data);
-  (replies || []).forEach((reply) => {
+  // _send() resolves to {} on its 5s timeout, so guard with Array.isArray
+  // rather than a truthy check ({} is truthy and has no .forEach). Mirrors the
+  // no-op-on-non-collection behaviour the former _.each gave here.
+  (Array.isArray(replies) ? replies : []).forEach((reply) => {
     this.setCommentReply(reply);
   });
   this.shouldCollectComment = true; // force collect the comment replies saved


### PR DESCRIPTION
## What

Removes the `underscore` runtime dependency, replacing every usage with a native equivalent across the four files that used it (`index.js`, `commentManager.js`, `static/js/copyPasteEvents.js`, `static/js/index.js`) and dropping it from `package.json`.

| underscore | native replacement |
|---|---|
| `_.object(keys, vals)` / `_.object(pairs)` | `Object.fromEntries(...)` |
| `_.zip(a, b)` | `a.map((v, i) => [v, b[i]])` |
| `_.mapObject(obj, fn)` | `Object.fromEntries(Object.entries(obj).map(...))` |
| `_.clone(x)` | `{...x}` / `[...x]` |
| `_.each(arr\|obj, fn)` | `Array.forEach` / `Object.entries(...).forEach` |
| `_.map(arr\|obj, fn)` | `Array.map` / `Object.entries\|values(...).map` |
| `_.extend(a, b)` | `Object.assign(a, b)` |
| `_.debounce(fn, wait)` | small local trailing-edge debounce |

### Behaviour-preserving details
- Helpers that were fed jQuery collections (`$(...).find(...)`) now call `.toArray()` first, keeping the element-iteration underscore did implicitly.
- Object-valued `_.each` / `_.map` keep underscore's `(value, key)` argument order.
- Null-safe guards (`|| {}`, `|| []`) mirror underscore's no-op-on-undefined where the old code depended on it.

## Test

No API change. Verified locally on **both** Etherpad 2.7.3 and develop:
- Full plugin frontend suite — **101 passed / 26 skipped** on each core (the copy-and-paste specs exercise the bulk of the rewritten helpers).
- Plugin backend suite — **58 passing** (`padCopy` covers the rewritten `commentManager.copyComments` / `copyCommentReplies`).

Pure JS — works on the latest release and develop without a core update.

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)