### PR TITLE
test: regression guard for suggestion text display (#188)

### DIFF
--- a/static/tests/frontend-new/specs/commentSuggestion.spec.ts
+++ b/static/tests/frontend-new/specs/commentSuggestion.spec.ts
@@ -1,7 +1,7 @@
 import {expect, test} from '@playwright/test';
 import {getPadBody, getPadOuter}
     from 'ep_etherpad-lite/tests/frontend-new/helper/padHelper';
-import {aNewCommentsPad} from '../helper/comments';
+import {aNewCommentsPad, reopenCommentsPad} from '../helper/comments';
 
 // Replace pad content with raw HTML and select all (mirrors legacy
 // `$firstTextElement.html(targetText).sendkeys('{selectall}')`).
@@ -97,5 +97,62 @@ test.describe('ep_comments_page - Comment Suggestion', () => {
     await expect.poll(async () =>
       (await inner.locator('div').first().locator('.comment').textContent())?.trim())
         .toBe(suggestedText);
+  });
+
+  // #188: "Suggestion text does not display". The original report was that the
+  // proposed ("to") text did not render in the comment box — only the
+  // {{changeTo}} placeholder showed — even though applying the change replaced
+  // the text correctly. Fixed by #369/#378 (the value now lives in its own
+  // .to-value span instead of a placeholder-substituted label). The existing
+  // test above covers the just-created in-memory render; this one guards the
+  // *persisted display* path by reloading the pad and reopening the comment,
+  // which rebuilds the box from getComments rather than the create flow.
+  test('Displays the suggested text after reload (#188)', async ({page}) => {
+    const inner = await getPadBody(page);
+    const suggestedText = 'the proposed replacement text';
+
+    // Type real text (not the innerHTML-injection helper) so the comment
+    // attribute survives a full reload, then select it and open the form.
+    await inner.click();
+    await page.keyboard.press('Control+A');
+    await page.keyboard.press('Delete');
+    await page.keyboard.type('This content will receive a comment');
+    await page.keyboard.press('Control+A');
+    await page.locator('.addComment').first().click();
+    await expect.poll(async () =>
+      page.locator('#newComment.popup-show .suggestion-checkbox').count()).toBeGreaterThan(0);
+    await page.locator('#newComment.popup-show .label-suggestion-checkbox').first().click();
+
+    await expect(page.locator('#newComment.popup-show')).toBeVisible();
+    await page.locator('#newComment textarea.comment-content').fill('A comment');
+    await expect.poll(async () =>
+      page.locator('#newComment textarea.to-value').count()).toBeGreaterThan(0);
+    await page.locator('#newComment textarea.to-value').fill(suggestedText);
+    await page.locator('#comment-create-btn').click();
+    await expect.poll(async () =>
+      inner.locator('div').first().locator('.comment').count()).toBeGreaterThan(0);
+
+    // Reload the pad as a fresh page load so the comment box is rebuilt from
+    // the server data (collectComments), not the create-time DOM.
+    const padId = page.url().split('/p/')[1].split(/[?#]/)[0];
+    await reopenCommentsPad(page, padId);
+
+    const innerAfter = await getPadBody(page);
+    const outerAfter = await getPadOuter(page);
+    await expect.poll(async () =>
+      innerAfter.locator('div').first().locator('.comment').count()).toBeGreaterThan(0);
+
+    // The suggestion box is pre-built in the sidebar on collect; the proposed
+    // text lives in its own .to-value span (textContent is present even while
+    // the box is collapsed). #188 was that this text was missing / showed the
+    // literal {{changeTo}} placeholder.
+    await expect.poll(async () => {
+      const t = await outerAfter.locator('.comment-container .comment-title-wrapper .to-value')
+          .first().textContent();
+      return (t || '').trim();
+    }, {timeout: 15_000}).toBe(suggestedText);
+    const titleText = await outerAfter.locator('.comment-container .comment-title-wrapper')
+        .first().textContent();
+    expect(titleText).not.toContain('{{');
   });
 });

--- a/static/tests/frontend-new/specs/commentSuggestion.spec.ts
+++ b/static/tests/frontend-new/specs/commentSuggestion.spec.ts
@@ -148,6 +148,21 @@ test.describe('ep_comments_page - Comment Suggestion', () => {
       return !!comments && Object.values(comments).some((c: any) => c && c.changeTo);
     }), {timeout: 15_000}).toBe(true);
 
+    // The metadata poll above only proves the comment record is stored. The
+    // inline highlight (and thus the rebuilt box) is reconstructed from the pad
+    // atext's `comment` attribute on reload, so also wait for the pad changeset
+    // that applies that attribute to be committed — i.e. the collab revision
+    // stops advancing. Reopening before that races persistence and loads a pad
+    // whose text carries no comment attribute (the flaky failure).
+    let lastRev = -1;
+    await expect.poll(async () => {
+      const rev = await page.evaluate(() =>
+        (window as any).pad?.getCollabRevisionNumber?.() ?? -1);
+      const stable = rev >= 1 && rev === lastRev;
+      lastRev = rev;
+      return stable;
+    }, {timeout: 15_000, intervals: [500]}).toBe(true);
+
     // Reload the pad as a fresh page load so the comment box is rebuilt from
     // the server data (collectComments), not the create-time DOM.
     await reopenCommentsPad(page, padId);

--- a/static/tests/frontend-new/specs/commentSuggestion.spec.ts
+++ b/static/tests/frontend-new/specs/commentSuggestion.spec.ts
@@ -132,9 +132,22 @@ test.describe('ep_comments_page - Comment Suggestion', () => {
     await expect.poll(async () =>
       inner.locator('div').first().locator('.comment').count()).toBeGreaterThan(0);
 
+    // Wait for the comment+suggestion to be persisted server-side before
+    // reloading: DOM presence in this session doesn't guarantee the save has
+    // round-tripped, and reloading too early can race persistence and load a
+    // pad that lacks the comment (flaky false failure). Poll the comments
+    // socket until the suggestion data is actually stored.
+    const padId = page.url().split('/p/')[1].split(/[?#]/)[0];
+    await expect.poll(async () => page.evaluate(async () => {
+      const ep = (window as any).pad?.plugins?.ep_comments_page;
+      if (!ep) return false;
+      const res = await ep.getComments();
+      const comments = res && res.comments ? res.comments : res;
+      return !!comments && Object.values(comments).some((c: any) => c && c.changeTo);
+    }), {timeout: 15_000}).toBe(true);
+
     // Reload the pad as a fresh page load so the comment box is rebuilt from
     // the server data (collectComments), not the create-time DOM.
-    const padId = page.url().split('/p/')[1].split(/[?#]/)[0];
     await reopenCommentsPad(page, padId);
 
     const innerAfter = await getPadBody(page);


### PR DESCRIPTION
## Background

[#188](https://github.com/ether/ep_comments_page/issues/188) reported that a suggestion's proposed text did not render in the comment box — only the literal `{{changeTo}}` placeholder appeared — even though *applying* the change replaced the pad text correctly. The root cause (unreliable `data-l10n-args` placeholder substitution) was fixed by #369 / #378, which moved the value into its own `.to-value` span instead of a placeholder-substituted label.

## What

Adds a regression test so the bug can't silently return. It:

1. Types **real** pad text (not the innerHTML-injection helper) so the `comment` attribute persists through a reload.
2. Creates a comment with a suggestion.
3. Reloads the pad (`reopenCommentsPad`) so the sidebar box is rebuilt from server data via `collectComments` — the exact path that was broken — rather than the create-time DOM the existing suggestion test covers.
4. Asserts the proposed text renders in `.to-value` and that the box contains no literal `{{` placeholder.

## Test

Test-only change. Verified locally on **both** Etherpad 2.7.3 and develop — full `Comment Suggestion` suite 4/4 passes on each core.

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)