### PR TITLE
fix(a11y): keep comment highlight visible in high-contrast mode (#217)

### DIFF
--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -7,6 +7,27 @@
   color: orange !important;
 }
 
+/* High-contrast / forced-colors mode (e.g. Windows High Contrast Mode), #217.
+   In forced-colors mode the UA discards the fixed yellow/dark fill above, so
+   commented text becomes indistinguishable from the rest of the document, and
+   the orange open-state colour is unreadable against the highlight. Opt back
+   into author colours with the system "marked text" pair — the semantic
+   colours browsers reserve for highlighted text — so the highlight stays
+   visible and legible whatever the active high-contrast palette is, and mark
+   the open comment with an outline (which forced-colors honours) instead of a
+   colour that cannot guarantee contrast. */
+@media (forced-colors: active) {
+  #innerdocbody .ace-line .comment {
+    background-color: Mark;
+    color: MarkText;
+    forced-color-adjust: none;
+  }
+  #innerdocbody .ace-line .comment[data-open="true"] {
+    color: MarkText !important;
+    outline: 2px solid CanvasText;
+  }
+}
+
 
 /* Comment right side container */
 #comments {

--- a/static/tests/frontend-new/specs/highContrast.spec.ts
+++ b/static/tests/frontend-new/specs/highContrast.spec.ts
@@ -9,7 +9,10 @@ import {aNewCommentsPad} from '../helper/comments';
 // pair under `@media (forced-colors: active)`. This spec drives Chromium's
 // forced-colors emulation and verifies the highlight survives.
 test.describe('ep_comments_page - High contrast / forced colors (#217)', () => {
-  test('comment highlight stays visible under forced-colors', async ({page}) => {
+  test('comment highlight stays visible under forced-colors', async ({page, browserName}) => {
+    // forced-colors emulation is only implemented in Chromium; guard so the
+    // suite stays correct if it is ever run under other Playwright projects.
+    test.skip(browserName !== 'chromium', 'forced-colors emulation is Chromium-only');
     await aNewCommentsPad(page);
     const inner = await getPadBody(page);
 
@@ -30,7 +33,7 @@ test.describe('ep_comments_page - High contrast / forced colors (#217)', () => {
     // Turn on forced-colors emulation (Windows High Contrast Mode equivalent).
     await page.emulateMedia({forcedColors: 'active'});
 
-    const style = await commentSpan.evaluate((el) => {
+    const readStyle = () => commentSpan.evaluate((el) => {
       const cs = getComputedStyle(el);
       return {
         background: cs.backgroundColor,
@@ -40,6 +43,15 @@ test.describe('ep_comments_page - High contrast / forced colors (#217)', () => {
       };
     });
 
+    // Forced-colors / media-query application can lag a tick, so poll until the
+    // forced-colors rule is actually reflected before asserting on the values.
+    await expect.poll(async () => {
+      const s = await readStyle();
+      return s.forcedColorAdjust === 'none' &&
+        s.background !== 'rgba(0, 0, 0, 0)' && s.background !== 'transparent';
+    }, {timeout: 10_000}).toBe(true);
+
+    const style = await readStyle();
     // Our forced-colors rule opts back into author colours...
     expect(style.forcedColorAdjust).toBe('none');
     // ...and keeps a real (non-transparent) highlight fill so commented text

--- a/static/tests/frontend-new/specs/highContrast.spec.ts
+++ b/static/tests/frontend-new/specs/highContrast.spec.ts
@@ -1,0 +1,53 @@
+import {expect, test} from '@playwright/test';
+import {getPadBody} from 'ep_etherpad-lite/tests/frontend-new/helper/padHelper';
+import {aNewCommentsPad} from '../helper/comments';
+
+// #217: in a high-contrast / forced-colors environment the inline comment
+// highlight (a fixed yellow fill with dark text) is discarded by the UA, so
+// commented text becomes indistinguishable from the rest of the document.
+// The CSS now re-asserts the highlight with the system "marked text" colour
+// pair under `@media (forced-colors: active)`. This spec drives Chromium's
+// forced-colors emulation and verifies the highlight survives.
+test.describe('ep_comments_page - High contrast / forced colors (#217)', () => {
+  test('comment highlight stays visible under forced-colors', async ({page}) => {
+    await aNewCommentsPad(page);
+    const inner = await getPadBody(page);
+
+    // Create a comment on real typed text.
+    await inner.click();
+    await page.keyboard.press('Control+A');
+    await page.keyboard.press('Delete');
+    await page.keyboard.type('commented text');
+    await inner.locator('div').first().click({clickCount: 3});
+    await page.locator('.addComment').click();
+    await expect(page.locator('#newComment.popup-show')).toBeVisible();
+    await page.locator('#newComment textarea.comment-content').fill('A comment');
+    await page.locator('#comment-create-btn').click();
+
+    const commentSpan = inner.locator('div').first().locator('.comment').first();
+    await expect.poll(async () => commentSpan.count()).toBeGreaterThan(0);
+
+    // Turn on forced-colors emulation (Windows High Contrast Mode equivalent).
+    await page.emulateMedia({forcedColors: 'active'});
+
+    const style = await commentSpan.evaluate((el) => {
+      const cs = getComputedStyle(el);
+      return {
+        background: cs.backgroundColor,
+        color: cs.color,
+        forcedColorAdjust: cs.forcedColorAdjust || (cs as any).getPropertyValue?.(
+            'forced-color-adjust'),
+      };
+    });
+
+    // Our forced-colors rule opts back into author colours...
+    expect(style.forcedColorAdjust).toBe('none');
+    // ...and keeps a real (non-transparent) highlight fill so commented text
+    // remains distinguishable instead of blending into the page.
+    expect(style.background).not.toBe('rgba(0, 0, 0, 0)');
+    expect(style.background).not.toBe('transparent');
+    // The highlight background and its text must not collapse to the same
+    // colour (which would make the text invisible).
+    expect(style.background).not.toBe(style.color);
+  });
+});


### PR DESCRIPTION
## Problem

[#217](https://github.com/ether/ep_comments_page/issues/217): in a high-contrast / forced-colors environment (e.g. Windows High Contrast Mode) you cannot read commented text. The inline highlight uses a fixed yellow fill with dark text; in forced-colors mode the UA discards author background/foreground colours, so the highlight disappears and commented text blends into the document. The `data-open="true"` orange colour is also unreadable against the highlight. The plugin's `highlightSelectedText` setting is unrelated (it only controls highlighting *while composing* a comment), which is why toggling it didn't help.

## Fix

Add an `@media (forced-colors: active)` block to `comment.css` that re-asserts the highlight using the **system "marked text" colour pair** — `Mark` / `MarkText`, the semantic colours browsers reserve for highlighted text — via `forced-color-adjust: none`. The open-comment state is marked with a `CanvasText` outline instead of a colour that can't guarantee contrast. The highlight then stays visible and legible under whatever high-contrast palette the user has active, rather than relying on a hard-coded yellow.

Pure CSS — works on the latest release (2.7.3) and develop without a core update.

## Test

Adds `highContrast.spec.ts`, which creates a comment, enables Chromium's forced-colors emulation (`page.emulateMedia({forcedColors: 'active'})`), and asserts the highlight opts back into author colours (`forced-color-adjust: none`) with a real, non-transparent fill distinct from its text colour.

Verified locally on **both** Etherpad 2.7.3 and develop — passes on each.

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)