### PR TITLE
fix(export): make comments survive rich-format exports (#190)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ To enable this feature, add the following code to your `settings.json`:
 
 **Warning**: there is a side effect when you enable this feature: a revision is created everytime the text is highlighted, resulting on apparently "empty" changes when you check your pad on the timeslider. If that is an issue for you, we don't recommend you to use this feature.
 
+### Comments in exported documents
+Comments are included when you export a pad. Each commented passage gets a
+numbered footnote marker (`[1]`, `[2]`, …) and a **Comments** section is appended
+listing each comment as `[n] author: text` (suggested changes are noted too).
+Because the markers are numbered they stay correlatable in rich formats such as
+**ODT, DOC, DOCX and PDF**, where the in-document anchor link is lost — so your
+comments are not silently dropped when you export. Plain-text (`.txt`) export
+omits comments, as the core text exporter has no extension point for them.
+
 ### Disable HTML export
 By default comments are exported to HTML, but if you don't wish to do that then you can disable it by adding the following to your `settings.json`:
 ```

--- a/exportHTML.js
+++ b/exportHTML.js
@@ -15,11 +15,19 @@ const findAllCommentUsedOn = (pad) => {
 exports.exportHtmlAdditionalTagsWithData =
   async (hookName, pad) => findAllCommentUsedOn(pad).map((name) => ['comment', name]);
 
+// Footnote-style marker for a comment. Numbering it (rather than a bare "*")
+// keeps the inline reference correlatable with the comment list once the export
+// is flattened to a rich format (odt/doc/pdf) where the `#id` anchor is lost.
+// Numbering follows the comments map order so both hooks agree (#190).
+const markerFor = (commentIds, commentId) => `[${commentIds.indexOf(commentId) + 1}]`;
+
 exports.getLineHTMLForExport = async (hookName, context) => {
   if (settings.ep_comments_page && settings.ep_comments_page.exportHtml === false) return;
 
   // I'm not sure how optimal this is - it will do a database lookup for each line..
   const {comments} = await commentManager.getComments(context.padId);
+  if (!comments) return;
+  const commentIds = Object.keys(comments);
   let hasPlugin = false;
   // Load the HTML into a throwaway div instead of calling $.load() to avoid
   // https://github.com/cheeriojs/cheerio/issues/1031
@@ -33,7 +41,7 @@ exports.getLineHTMLForExport = async (hookName, context) => {
     hasPlugin = true;
     span.append(
         $('<sup>').append(
-            $('<a>').attr('href', `#${commentId}`).text('*')));
+            $('<a>').attr('href', `#${commentId}`).text(markerFor(commentIds, commentId))));
     // Replace data-comment="foo" with class="comment foo".
     if (/^c-[0-9a-zA-Z]+$/.test(commentId)) {
       span.removeAttr('data-comment').addClass('comment').addClass(commentId);
@@ -45,15 +53,26 @@ exports.getLineHTMLForExport = async (hookName, context) => {
 exports.exportHTMLAdditionalContent = async (hookName, {padId}) => {
   if (settings.ep_comments_page && settings.ep_comments_page.exportHtml === false) return;
   const {comments} = await commentManager.getComments(padId);
-  if (!comments) return;
+  if (!comments || !Object.keys(comments).length) return;
+  const commentIds = Object.keys(comments);
   const div = $('<div>').attr('id', 'comments');
+  // A heading so the block is recognisable once flattened into odt/doc/pdf,
+  // where the surrounding markup is gone.
+  div.append($('<h2>').text('Comments'));
   for (const [commentId, comment] of Object.entries(comments)) {
-    div.append(
-        $('<p>')
-            .attr('role', 'comment')
-            .addClass('comment')
-            .attr('id', commentId)
-            .text(`* ${comment.text}`));
+    // Build "[n] author: text" with an optional suggested-change clause so the
+    // full comment survives into rich-format exports (#190). Assemble via text
+    // nodes so author/comment content can't inject markup.
+    const p = $('<p>')
+        .attr('role', 'comment')
+        .addClass('comment')
+        .attr('id', commentId);
+    const marker = markerFor(commentIds, commentId);
+    const author = (comment.name && String(comment.name).trim()) || 'Anonymous';
+    let line = `${marker} ${author}: ${comment.text || ''}`;
+    if (comment.changeTo) line += ` (suggested change to: "${comment.changeTo}")`;
+    p.text(line);
+    div.append(p);
   }
   // adds additional HTML to the body, we get this HTML from the database of comments:padId
   return $.html(div);

--- a/exportHTML.js
+++ b/exportHTML.js
@@ -15,11 +15,18 @@ const findAllCommentUsedOn = (pad) => {
 exports.exportHtmlAdditionalTagsWithData =
   async (hookName, pad) => findAllCommentUsedOn(pad).map((name) => ['comment', name]);
 
-// Footnote-style marker for a comment. Numbering it (rather than a bare "*")
+// Footnote-style markers for comments. Numbering them (rather than a bare "*")
 // keeps the inline reference correlatable with the comment list once the export
 // is flattened to a rich format (odt/doc/pdf) where the `#id` anchor is lost.
 // Numbering follows the comments map order so both hooks agree (#190).
-const markerFor = (commentIds, commentId) => `[${commentIds.indexOf(commentId) + 1}]`;
+// Build a commentId -> "[n]" lookup once so per-span/per-comment marker
+// resolution is O(1) instead of an indexOf scan per call (avoids O(n^2) over
+// many comments, #190).
+const buildMarkerMap = (commentIds) => {
+  const markers = new Map();
+  commentIds.forEach((id, i) => markers.set(id, `[${i + 1}]`));
+  return markers;
+};
 
 exports.getLineHTMLForExport = async (hookName, context) => {
   if (settings.ep_comments_page && settings.ep_comments_page.exportHtml === false) return;
@@ -28,6 +35,7 @@ exports.getLineHTMLForExport = async (hookName, context) => {
   const {comments} = await commentManager.getComments(context.padId);
   if (!comments) return;
   const commentIds = Object.keys(comments);
+  const markers = buildMarkerMap(commentIds);
   let hasPlugin = false;
   // Load the HTML into a throwaway div instead of calling $.load() to avoid
   // https://github.com/cheeriojs/cheerio/issues/1031
@@ -41,7 +49,7 @@ exports.getLineHTMLForExport = async (hookName, context) => {
     hasPlugin = true;
     span.append(
         $('<sup>').append(
-            $('<a>').attr('href', `#${commentId}`).text(markerFor(commentIds, commentId))));
+            $('<a>').attr('href', `#${commentId}`).text(markers.get(commentId))));
     // Replace data-comment="foo" with class="comment foo".
     if (/^c-[0-9a-zA-Z]+$/.test(commentId)) {
       span.removeAttr('data-comment').addClass('comment').addClass(commentId);
@@ -55,6 +63,7 @@ exports.exportHTMLAdditionalContent = async (hookName, {padId}) => {
   const {comments} = await commentManager.getComments(padId);
   if (!comments || !Object.keys(comments).length) return;
   const commentIds = Object.keys(comments);
+  const markers = buildMarkerMap(commentIds);
   const div = $('<div>').attr('id', 'comments');
   // A heading so the block is recognisable once flattened into odt/doc/pdf,
   // where the surrounding markup is gone.
@@ -67,7 +76,7 @@ exports.exportHTMLAdditionalContent = async (hookName, {padId}) => {
         .attr('role', 'comment')
         .addClass('comment')
         .attr('id', commentId);
-    const marker = markerFor(commentIds, commentId);
+    const marker = markers.get(commentId);
     const author = (comment.name && String(comment.name).trim()) || 'Anonymous';
     let line = `${marker} ${author}: ${comment.text || ''}`;
     if (comment.changeTo) line += ` (suggested change to: "${comment.changeTo}")`;

--- a/static/tests/frontend-new/specs/exportComments.spec.ts
+++ b/static/tests/frontend-new/specs/exportComments.spec.ts
@@ -1,0 +1,65 @@
+import {expect, test} from '@playwright/test';
+import {getPadBody} from 'ep_etherpad-lite/tests/frontend-new/helper/padHelper';
+import {aNewCommentsPad} from '../helper/comments';
+
+// #190: comments were lost when exporting to rich formats. The plugin's export
+// hooks (getLineHTMLForExport + exportHTMLAdditionalContent) put the comments
+// into the HTML document that every rich format (odt/doc/pdf/docx) is rendered
+// from, so they survive the conversion. This spec exercises the HTML export
+// (deterministic, no soffice dependency) and verifies the comments are present
+// and footnote-numbered so they stay correlatable once the anchor is flattened.
+test.describe('ep_comments_page - Export comments (#190)', () => {
+  test.beforeEach(({page}) => { test.setTimeout(60_000); void page; });
+
+  const addComment = async (
+    page: import('@playwright/test').Page, lineIndex: number, commentText: string,
+  ) => {
+    const inner = await getPadBody(page);
+    // Select the line and open the form. Retry the trigger until the popup
+    // shows — the triple-click selection occasionally races the toolbar.
+    await expect.poll(async () => {
+      await inner.locator('div').nth(lineIndex).click({clickCount: 3});
+      await page.locator('.addComment').click();
+      return page.locator('#newComment.popup-show').count();
+    }, {timeout: 20_000}).toBeGreaterThan(0);
+    await page.locator('#newComment textarea.comment-content').fill(commentText);
+    await page.locator('#comment-create-btn').click();
+    // Wait for the inline highlight to appear before moving on.
+    await expect.poll(async () =>
+      inner.locator('div').nth(lineIndex).locator('.comment').count()).toBeGreaterThan(0);
+  };
+
+  test('comments are exported into the HTML document', async ({page}) => {
+    const padId = await aNewCommentsPad(page);
+    const inner = await getPadBody(page);
+    await inner.click();
+    await page.keyboard.press('Control+A');
+    await page.keyboard.press('Delete');
+    await page.keyboard.type('First commented line');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Second commented line');
+
+    await addComment(page, 0, 'FIRST_COMMENT_MARKER');
+    await addComment(page, 1, 'SECOND_COMMENT_MARKER');
+
+    const base = page.url().split('/p/')[0];
+    const html: string = await page.evaluate(async (url) =>
+      await (await fetch(url)).text(), `${base}/p/${padId}/export/html`);
+
+    // Both comment texts must be present in the exported document.
+    expect(html).toContain('FIRST_COMMENT_MARKER');
+    expect(html).toContain('SECOND_COMMENT_MARKER');
+    // A recognisable comments section survives for flattened formats.
+    expect(html).toContain('<div id="comments">');
+    expect(html).toContain('Comments');
+    // Footnote markers are numbered (not all "*") so they stay correlatable
+    // once the #id anchor is lost in odt/doc/pdf.
+    expect(html).toContain('[1]');
+    expect(html).toContain('[2]');
+    // Inline markers link to the comment ids.
+    expect(html).toMatch(/<sup><a href="#c-[0-9a-zA-Z]+">\[1\]<\/a><\/sup>/);
+    // Each comment line carries its number, author and text in the section.
+    expect(html).toMatch(/\[1\][^<]*FIRST_COMMENT_MARKER/);
+    expect(html).toMatch(/\[2\][^<]*SECOND_COMMENT_MARKER/);
+  });
+});


### PR DESCRIPTION
## Problem

[#190](https://github.com/ether/ep_comments_page/issues/190): exporting a pad to a rich format (ODT/PDF/DOC/DOCX) appeared to lose comments — serious silent data loss.

Investigating the current pipeline: comments **are** injected into the exported HTML document (`getLineHTMLForExport` adds an inline marker, `exportHTMLAdditionalContent` appends a comments block), and `getPadHTMLDocument` — which feeds **every** rich format — calls both hooks. I verified with `soffice` that the comment text reaches both ODT (`content.xml`) and PDF. So the rich formats already carry the comment *text*.

The real defect: every inline marker was an identical `*`, and the in-document `<a href="#id">` anchor is meaningless once the document is flattened to ODT/PDF. With more than one comment you couldn't tell which footnote belonged to which passage, and the comment author was dropped entirely.

## Fix

- **Number the footnote markers** (`[1]`, `[2]`, …) so they stay correlatable after the anchor is lost.
- Add a **Comments** heading and render each entry as `[n] author: text`, appending `(suggested change to: "…")` for suggestions.
- Number both hooks from the same comments-map order so inline markers and the list always agree.
- Text nodes only — author/comment content can't inject markup.

Plain-text (`.txt`) export still omits comments: core's `ExportTxt` exposes no plugin hook on either supported core, so it can't be fixed plugin-side without a core change. Documented in the README. (Markdown is not a core export format.)

Pure plugin change — works on the latest release (2.7.3) and develop without a core update.

## Test

Adds `exportComments.spec.ts`: creates two comments, fetches `/export/html`, and asserts both comment texts, the `Comments` section, and the distinct numbered markers (`[1]`/`[2]`) are present and correlated. Verified locally on **both** Etherpad 2.7.3 and develop, and confirmed ODT/PDF output via `soffice` manually.

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)