### PR TITLE
fix(mobile): keep the comment popup on-screen on small viewports (#192)

### DIFF
--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -199,6 +199,12 @@ input.error, textarea.error {
 .comment-modal {
   bottom: auto !important;
   right: auto !important;
+  /* Never let the popup grow wider than the viewport, otherwise it spills off
+     the right edge on narrow / mobile screens regardless of its left position
+     (#192). Pairs with the left/right clamp in commentBoxes.js. */
+  max-width: calc(100% - 20px);
+  box-sizing: border-box;
+  overflow-wrap: break-word;
 }
 .comment-modal-comment {
   padding: 0;

--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -203,10 +203,14 @@ input.error, textarea.error {
 .comment-modal {
   bottom: auto !important;
   right: auto !important;
+  /* Single source of truth for the viewport safe-margin so the CSS width cap
+     and the JS left/top clamp can't drift apart (#192). commentBoxes.js reads
+     this custom property back via getComputedStyle. */
+  --comment-modal-margin: 10px;
   /* Never let the popup grow wider than the viewport, otherwise it spills off
      the right edge on narrow / mobile screens regardless of its left position
      (#192). Pairs with the left/right clamp in commentBoxes.js. */
-  max-width: calc(100% - 20px);
+  max-width: calc(100% - (2 * var(--comment-modal-margin)));
   box-sizing: border-box;
   overflow-wrap: break-word;
 }

--- a/static/js/commentBoxes.js
+++ b/static/js/commentBoxes.js
@@ -76,15 +76,19 @@ const highlightComment = (commentId, e, editorComment) => {
       targetLeft = $(e.target).offset().left - 20;
     }
 
-    // if positioning modal on target left will make part of the modal to be
-    // out of screen, we place it closer to the middle of the screen
-    if (targetLeft + modalWitdh > containerWidth) {
-      targetLeft = containerWidth - modalWitdh - 25;
-    }
+    // Clamp horizontally so the modal never spills off either edge. The old
+    // code only guarded the right edge, which left the popup half off-screen
+    // (or pushed it past the left edge from the icon's `offset - 20`) on
+    // narrow / mobile viewports (#192). max() keeps the left margin valid even
+    // when the modal is wider than the container.
+    const margin = 10;
+    const maxLeft = Math.max(margin, containerWidth - modalWitdh - margin);
+    targetLeft = Math.min(Math.max(targetLeft, margin), maxLeft);
     const editorCommentHeight = editorComment ? editorComment.outerHeight(true) : 30;
+    targetTop = Math.max(margin, targetTop + editorCommentHeight);
     getPadOuter().find('.comment-modal').addClass('popup-show').css({
       left: `${targetLeft}px`,
-      top: `${targetTop + editorCommentHeight}px`,
+      top: `${targetTop}px`,
     });
   }
 };

--- a/static/js/commentBoxes.js
+++ b/static/js/commentBoxes.js
@@ -81,7 +81,13 @@ const highlightComment = (commentId, e, editorComment) => {
     // (or pushed it past the left edge from the icon's `offset - 20`) on
     // narrow / mobile viewports (#192). max() keeps the left margin valid even
     // when the modal is wider than the container.
-    const margin = 10;
+    // Read the safe-margin from the CSS custom property so JS and CSS stay in
+    // sync (single source of truth on .comment-modal); fall back to 10px.
+    const $modal = getPadOuter().find('.comment-modal');
+    const marginProp = $modal.length
+      ? parseFloat(getComputedStyle($modal[0]).getPropertyValue('--comment-modal-margin'))
+      : NaN;
+    const margin = Number.isFinite(marginProp) ? marginProp : 10;
     const maxLeft = Math.max(margin, containerWidth - modalWitdh - margin);
     targetLeft = Math.min(Math.max(targetLeft, margin), maxLeft);
     const editorCommentHeight = editorComment ? editorComment.outerHeight(true) : 30;

--- a/static/tests/frontend-new/specs/mobilePopup.spec.ts
+++ b/static/tests/frontend-new/specs/mobilePopup.spec.ts
@@ -1,0 +1,56 @@
+import {expect, test} from '@playwright/test';
+import {getPadBody, getPadOuter} from 'ep_etherpad-lite/tests/frontend-new/helper/padHelper';
+import {aNewCommentsPad} from '../helper/comments';
+
+// #192: on small / mobile viewports the comment sidebar is hidden and comments
+// open in a floating ".comment-modal" instead. The modal was positioned with
+// only a right-edge guard, so it spilled off-screen (the reported iPad bug).
+// This spec uses a narrow viewport (below the 900px sidebar breakpoint) to take
+// the modal path and asserts the popup stays fully within the viewport.
+test.describe('ep_comments_page - Mobile comment popup (#192)', () => {
+  const VIEWPORT = {width: 320, height: 700};
+  test.use({viewport: VIEWPORT});
+
+  test('comment modal stays within the viewport', async ({page}) => {
+    test.setTimeout(60_000);
+    await aNewCommentsPad(page);
+    const inner = await getPadBody(page);
+    const outer = await getPadOuter(page);
+
+    // A long unbreakable comment is the realistic trigger: on a narrow screen
+    // the cloned box would grow past the viewport (no wrapping / no width cap),
+    // which is when the old right-only clamp placed it off-screen.
+    const longComment = 'ThisIsAnExtremelyLongUnbreakableCommentStringWithoutAnySpaces' +
+      'ThatWouldOtherwiseStretchTheModalWayBeyondTheEdgeOfANarrowPhoneScreen';
+
+    await inner.click();
+    await page.keyboard.press('Control+A');
+    await page.keyboard.press('Delete');
+    await page.keyboard.type('A passage that will be commented on the phone');
+    await inner.locator('div').first().click({clickCount: 3});
+    await page.locator('.addComment').click();
+    await expect(page.locator('#newComment.popup-show')).toBeVisible();
+    await page.locator('#newComment textarea.comment-content').fill(longComment);
+    await page.locator('#comment-create-btn').click();
+
+    const commentSpan = inner.locator('div').first().locator('.comment').first();
+    await expect.poll(async () => commentSpan.count()).toBeGreaterThan(0);
+
+    // Tap the commented text to open the floating modal (sidebar is hidden at
+    // this width, so highlightComment takes the modal branch).
+    await commentSpan.click();
+
+    const modal = outer.locator('.comment-modal.popup-show');
+    await expect(modal).toBeVisible();
+
+    // The modal must be fully on screen: not past the left edge, not past the
+    // right edge. boundingBox() is relative to the top-level viewport.
+    const box = await modal.boundingBox();
+    expect(box).not.toBeNull();
+    const tolerance = 2;
+    expect(box!.x).toBeGreaterThanOrEqual(-tolerance);
+    expect(box!.x + box!.width).toBeLessThanOrEqual(VIEWPORT.width + tolerance);
+    // And it should have a real width (not collapsed).
+    expect(box!.width).toBeGreaterThan(0);
+  });
+});

--- a/static/tests/frontend-new/specs/mobilePopup.spec.ts
+++ b/static/tests/frontend-new/specs/mobilePopup.spec.ts
@@ -5,8 +5,11 @@ import {aNewCommentsPad} from '../helper/comments';
 // #192: on small / mobile viewports the comment sidebar is hidden and comments
 // open in a floating ".comment-modal" instead. The modal was positioned with
 // only a right-edge guard, so it spilled off-screen (the reported iPad bug).
-// This spec uses a narrow viewport (below the 900px sidebar breakpoint) to take
-// the modal path and asserts the popup stays fully within the viewport.
+// This spec uses a narrow viewport to take the modal path and asserts the popup
+// stays fully within the viewport. Rather than hard-coding the sidebar
+// breakpoint, it asserts the sidebar is actually hidden first, so the test
+// fails loudly (instead of silently exercising the sidebar path) if the
+// breakpoint ever changes.
 test.describe('ep_comments_page - Mobile comment popup (#192)', () => {
   const VIEWPORT = {width: 320, height: 700};
   test.use({viewport: VIEWPORT});
@@ -36,8 +39,13 @@ test.describe('ep_comments_page - Mobile comment popup (#192)', () => {
     const commentSpan = inner.locator('div').first().locator('.comment').first();
     await expect.poll(async () => commentSpan.count()).toBeGreaterThan(0);
 
-    // Tap the commented text to open the floating modal (sidebar is hidden at
-    // this width, so highlightComment takes the modal branch).
+    // Precondition: the sidebar must be hidden at this viewport so that
+    // highlightComment takes the modal branch. Assert it explicitly so a
+    // breakpoint change surfaces as a clear failure here rather than silently
+    // exercising the sidebar path.
+    await expect(outer.locator('#comments')).toBeHidden();
+
+    // Tap the commented text to open the floating modal.
     await commentSpan.click();
 
     const modal = outer.locator('.comment-modal.popup-show');


### PR DESCRIPTION
## Problem

[#192](https://github.com/ether/ep_comments_page/issues/192): on iPad / mobile the comment popup is displayed in the wrong place. On small viewports the sidebar is hidden and comments open in a floating `.comment-modal`. Its positioning logic only clamped the **right** edge, and the comment-icon branch set `left = offset().left - 20` with no lower bound — so the popup could be pushed past the left edge or land partly off-screen. The modal also had no width cap, so a long/unbreakable comment could stretch it beyond the viewport.

## Fix

Harden the modal positioning in `commentBoxes.js` and `comment.css`:

- Clamp the modal's left within `[margin, containerWidth - modalWidth - margin]` (floored at `margin`) so it can never spill off **either** edge.
- Floor the top at `margin`.
- CSS: cap `.comment-modal` at `max-width: calc(100% - 20px)` with `box-sizing: border-box` and `overflow-wrap: break-word`, so wide content wraps instead of overflowing.

Pure plugin change — works on the latest release (2.7.3) and develop without a core update.

## Test

Adds `mobilePopup.spec.ts`, which opens a comment on a narrow **320px** viewport (below the sidebar breakpoint, so the modal branch is taken) and asserts the opened modal stays within the viewport bounds. Verified locally on **both** Etherpad 2.7.3 and develop.

**Transparency:** the exact iPad-Safari misplacement can't be reproduced in CI's headless Chromium — it stems from Safari's `clientX` behaviour inside a zoomed/scrolled iframe, which Chromium emulation doesn't replicate. The test therefore guards the *on-screen invariant* rather than the device-specific coordinate quirk; the positioning hardening cannot regress the desktop path.

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)