### PR TITLE
fix: stop same-line comment boxes from overlapping (#181)

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -653,30 +653,48 @@ EpComments.prototype.setYofComments = function () {
   const padInner = padOuter.find('iframe[name="ace_inner"]');
   const inlineComments = this.getFirstOcurrenceOfCommentIds();
   const commentsToBeShown = [];
+  const innerPaddingTop = parseInt(padInner.css('padding-top').split('px')[0]) || 0;
 
+  // First pass: compute each comment box's natural target top (aligned to its
+  // commented text). Collected up-front so the second pass can de-overlap
+  // comments that share a line (#181) instead of stacking them at the same Y.
+  const targets = [];
   $.each(inlineComments, function () {
-    // classname is the ID of the comment
-    const commentId = /(?:^| )(c-[A-Za-z0-9]*)/.exec(this.className);
-    if (!commentId || !commentId[1]) return;
-    const commentEle = padOuter.find(`#${commentId[1]}`);
-
-    let topOffset = this.offsetTop;
-    topOffset += parseInt(padInner.css('padding-top').split('px')[0]);
-    topOffset += parseInt($(this).css('padding-top').split('px')[0]);
-
-    if (commentId) {
-      // adjust outer comment...
-      commentBoxes.adjustTopOf(commentId[1], topOffset);
-      // ... and adjust icons too
-      commentIcons.adjustTopOf(commentId[1], topOffset);
-
-      // mark this comment to be displayed if it was visible before we start adjusting its position
-      if (commentIcons.shouldShow(commentEle)) commentsToBeShown.push(commentEle);
-    }
+    const match = /(?:^| )(c-[A-Za-z0-9]*)/.exec(this.className);
+    if (!match || !match[1]) return;
+    let topOffset = this.offsetTop + innerPaddingTop;
+    topOffset += parseInt($(this).css('padding-top').split('px')[0]) || 0;
+    targets.push({commentId: match[1], top: topOffset});
   });
 
+  // Lay the boxes out top-to-bottom. When two comments resolve to the same (or
+  // overlapping) Y — e.g. two comments on one line — push the later one down so
+  // both stay visible and clickable instead of overlapping (#181). Comments on
+  // distinct lines keep their natural position because their natural top is
+  // already past the previous box's bottom.
+  targets.sort((a, b) => a.top - b.top);
+  const gap = 4;
+  let lastBottom = -Infinity;
+  for (const target of targets) {
+    const commentEle = padOuter.find(`#${target.commentId}`);
+    const top = Math.max(target.top, lastBottom + gap);
+    // adjust outer comment...
+    commentBoxes.adjustTopOf(target.commentId, top);
+    // ... and adjust icons too (icons stay aligned to the text line)
+    commentIcons.adjustTopOf(target.commentId, target.top);
+
+    // A collapsed box is a single compact line; measure it so the next box
+    // clears it. outerHeight may be 0 if the box is hidden — fall back to a
+    // sensible compact-row height so stacking still separates them.
+    const height = commentEle.outerHeight(true) || 24;
+    lastBottom = top + height;
+
+    // mark this comment to be displayed if it was visible before we start adjusting its position
+    if (commentIcons.shouldShow(commentEle)) commentsToBeShown.push(commentEle);
+  }
+
   // re-display comments that were visible before
-  _.each(commentsToBeShown, (commentEle) => {
+  commentsToBeShown.forEach((commentEle) => {
     commentEle.show();
   });
 };

--- a/static/tests/frontend-new/specs/multipleCommentsPerLine.spec.ts
+++ b/static/tests/frontend-new/specs/multipleCommentsPerLine.spec.ts
@@ -1,0 +1,62 @@
+import {expect, test} from '@playwright/test';
+import {getPadBody, getPadOuter} from 'ep_etherpad-lite/tests/frontend-new/helper/padHelper';
+import {aNewCommentsPad} from '../helper/comments';
+
+// #181 (ether/etherpad-lite#4627): two comments on the same line both aligned
+// their sidebar box to the same Y, so the boxes overlapped and one became
+// hidden / unclickable. setYofComments now de-overlaps boxes that share a line.
+test.describe('ep_comments_page - Multiple comments on one line (#181)', () => {
+  test('sidebar boxes for same-line comments do not overlap', async ({page}) => {
+    test.setTimeout(60_000);
+    await aNewCommentsPad(page);
+    const inner = await getPadBody(page);
+    const outer = await getPadOuter(page);
+    const line = inner.locator('div').first();
+
+    const addCommentForSelection = async (text: string) => {
+      await page.locator('.addComment').click();
+      await expect(page.locator('#newComment.popup-show')).toBeVisible();
+      await page.locator('#newComment textarea.comment-content').fill(text);
+      await page.locator('#comment-create-btn').click();
+      // The create popup closes once the comment is committed.
+      await expect(page.locator('#newComment.popup-show')).toBeHidden();
+    };
+
+    await inner.click();
+    await page.keyboard.press('Control+A');
+    await page.keyboard.press('Delete');
+    await page.keyboard.type('hello world');
+
+    // Select "hello" (first 5 chars) and comment it.
+    await line.click();
+    await page.keyboard.press('Home');
+    for (let i = 0; i < 5; i++) await page.keyboard.press('Shift+ArrowRight');
+    await addCommentForSelection('comment on hello');
+
+    // Re-focus the editor (the create popup stole focus), then select "world".
+    await line.click();
+    await page.keyboard.press('End');
+    for (let i = 0; i < 5; i++) await page.keyboard.press('Shift+ArrowLeft');
+    await addCommentForSelection('comment on world');
+
+    // Both comments keep their own inline highlight on the one line...
+    await expect.poll(async () => line.locator('.comment').count()).toBeGreaterThanOrEqual(2);
+    // ...and each has its own sidebar box.
+    const boxes = outer.locator('#comments .sidebar-comment');
+    await expect.poll(async () => boxes.count()).toBe(2);
+
+    const rects = await boxes.evaluateAll((els) =>
+      els.map((el) => {
+        const r = (el as HTMLElement).getBoundingClientRect();
+        return {top: r.top, bottom: r.bottom, height: r.height};
+      }));
+    rects.sort((a, b) => a.top - b.top);
+
+    // The boxes must be stacked, not piled on the same Y: the lower box must
+    // start at (or below) the upper box's bottom, with a little tolerance.
+    const tolerance = 4;
+    expect(rects[0].height).toBeGreaterThan(0);
+    expect(rects[1].height).toBeGreaterThan(0);
+    expect(rects[1].top).toBeGreaterThanOrEqual(rects[0].bottom - tolerance);
+  });
+});


### PR DESCRIPTION
## Problem

[#181](https://github.com/ether/ep_comments_page/issues/181) / [ether/etherpad-lite#4627](https://github.com/ether/etherpad-lite/issues/4627): when two comments are on the same line, both sidebar boxes were positioned at the same Y (the line's `offsetTop`), so they piled directly on top of each other. One comment ended up hidden and you couldn't select / accept / reply to it.

## Fix

Rework `setYofComments` into two passes:

1. Collect every box's *natural* target top (aligned to its commented text).
2. Lay the boxes out top-to-bottom, sorted by that natural top, pushing a box down to clear the previous one whenever their natural positions would collide.

Boxes on distinct lines are unaffected — their natural top already clears the box above, so only genuinely-overlapping (same-line) comments get stacked. Comment icons stay aligned to their text line.

Pure client change — works on the latest release (2.7.3) and develop without a core update.

## Test

Adds `multipleCommentsPerLine.spec.ts`: puts two comments on a single line (`hello` / `world`) and asserts the two sidebar boxes are stacked, not overlapping. Confirmed it **fails** against the old single-pass positioning (both boxes at the same Y) and **passes** with the fix.

Verified locally on **both** Etherpad 2.7.3 and develop; the full plugin frontend suite (102 passed / 26 skipped) stays green, so existing comment-positioning behaviour is unaffected.

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)