### PR TITLE
feat: hide edit/delete comment actions on read-only pads (#112)

### DIFF
--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -218,6 +218,16 @@ input.error, textarea.error {
   margin-top: 0 !important;
 }
 
+/* READ-ONLY: hide write-only comment actions (edit / delete) on read-only
+   pads (#112). The comment sidebar and modal live in the ace_outer iframe,
+   which does not receive core's `readonly` body class, so the plugin tags the
+   outer body with `comments-readonly` itself (see static/js/index.js). The
+   server already rejects edits/deletes from read-only sessions; this removes
+   the now-dead controls from the UI. */
+.comments-readonly .comment-actions-wrapper {
+  display: none !important;
+}
+
 /* OTHER */
 .hidden {
   display: none;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -100,6 +100,14 @@ EpComments.prototype.init = async function () {
   this.findContainers();
   this.insertContainers(); // Insert comment containers in sidebar
 
+  // On read-only pads, tag the outer body so the CSS can hide the edit/delete
+  // controls (#112). The sidebar lives in the ace_outer iframe, which doesn't
+  // get core's `readonly` body class. The server already rejects writes from
+  // read-only sessions; this just removes the dead controls from the UI.
+  if (clientVars.readonly && this.outerBody) {
+    this.outerBody.addClass('comments-readonly');
+  }
+
   // Init icons container
   commentIcons.insertContainer();
 

--- a/static/tests/frontend-new/specs/readonlyHideActions.spec.ts
+++ b/static/tests/frontend-new/specs/readonlyHideActions.spec.ts
@@ -32,11 +32,15 @@ test.describe('ep_comments_page - Read-only hides comment actions (#112)', () =>
         await expect.poll(async () =>
           inner.locator('div').first().locator('.comment').count()).toBeGreaterThan(0);
 
-        // Sanity: on the writable pad the actions wrapper exists and is visible.
+        // Sanity: on the writable pad the actions wrapper is actually visible.
+        // The wrapper lives under .full-display-content (hidden until the box is
+        // expanded), so expand the box first and assert real visibility rather
+        // than just the wrapper's own display value.
         await expect.poll(async () =>
           outer.locator('#comments .comment-actions-wrapper').count()).toBeGreaterThan(0);
-        expect(await outer.locator('#comments .comment-actions-wrapper').first()
-            .evaluate((el) => window.getComputedStyle(el).display)).not.toBe('none');
+        await outer.locator('#comments .sidebar-comment').first()
+            .evaluate((el) => el.classList.add('full-display'));
+        await expect(outer.locator('#comments .comment-actions-wrapper').first()).toBeVisible();
 
         // Wait for the comment to persist, then open the read-only view.
         const readOnlyId: string = await page.evaluate(async () => {
@@ -61,12 +65,14 @@ test.describe('ep_comments_page - Read-only hides comment actions (#112)', () =>
         await expect.poll(async () =>
           roOuter.locator('#comments .sidebar-comment').count()).toBeGreaterThan(0);
 
-        // The actions wrapper is present in the DOM but hidden by the CSS.
+        // The actions wrapper is present in the DOM but hidden by the CSS — even
+        // when the box is expanded (so .full-display-content is shown), the
+        // wrapper stays hidden by the comments-readonly rule.
         await expect.poll(async () =>
           roOuter.locator('#comments .comment-actions-wrapper').count()).toBeGreaterThan(0);
-        const display = await roOuter.locator('#comments .comment-actions-wrapper').first()
-            .evaluate((el) => window.getComputedStyle(el).display);
-        expect(display).toBe('none');
+        await roOuter.locator('#comments .sidebar-comment').first()
+            .evaluate((el) => el.classList.add('full-display'));
+        await expect(roOuter.locator('#comments .comment-actions-wrapper').first()).toBeHidden();
         // And the outer body carries the marker class.
         expect(await roOuter.locator('#outerdocbody.comments-readonly').count())
             .toBeGreaterThan(0);

--- a/static/tests/frontend-new/specs/readonlyHideActions.spec.ts
+++ b/static/tests/frontend-new/specs/readonlyHideActions.spec.ts
@@ -1,0 +1,74 @@
+import {expect, test} from '@playwright/test';
+import {getPadBody, getPadOuter} from 'ep_etherpad-lite/tests/frontend-new/helper/padHelper';
+import {aNewCommentsPad} from '../helper/comments';
+
+// #112: on a read-only pad the edit/delete comment controls should not be
+// shown — the server already rejects those writes, so the buttons are dead.
+// The comment sidebar lives in the ace_outer iframe, which doesn't get core's
+// `readonly` body class, so the plugin tags it `comments-readonly` and the CSS
+// hides .comment-actions-wrapper there.
+test.describe('ep_comments_page - Read-only hides comment actions (#112)', () => {
+  test('edit/delete actions are hidden on the read-only pad but shown on r/w',
+      async ({page}) => {
+        test.setTimeout(60_000);
+        await aNewCommentsPad(page);
+        const inner = await getPadBody(page);
+        const outer = await getPadOuter(page);
+
+        // Create a comment on typed text.
+        await inner.click();
+        await page.keyboard.press('Control+A');
+        await page.keyboard.press('Delete');
+        await page.keyboard.type('text that will be commented');
+        // Retry the selection + trigger until the form shows (the triple-click
+        // selection can race the toolbar on a freshly loaded pad).
+        await expect.poll(async () => {
+          await inner.locator('div').first().click({clickCount: 3});
+          await page.locator('.addComment').click();
+          return page.locator('#newComment.popup-show').count();
+        }, {timeout: 20_000}).toBeGreaterThan(0);
+        await page.locator('#newComment textarea.comment-content').fill('a comment');
+        await page.locator('#comment-create-btn').click();
+        await expect.poll(async () =>
+          inner.locator('div').first().locator('.comment').count()).toBeGreaterThan(0);
+
+        // Sanity: on the writable pad the actions wrapper exists and is visible.
+        await expect.poll(async () =>
+          outer.locator('#comments .comment-actions-wrapper').count()).toBeGreaterThan(0);
+        expect(await outer.locator('#comments .comment-actions-wrapper').first()
+            .evaluate((el) => window.getComputedStyle(el).display)).not.toBe('none');
+
+        // Wait for the comment to persist, then open the read-only view.
+        const readOnlyId: string = await page.evaluate(async () => {
+          const w = window as any;
+          // Ensure the comment is stored before we switch pads.
+          await w.pad.plugins.ep_comments_page.getComments();
+          return w.clientVars.readOnlyId;
+        });
+        expect(readOnlyId).toMatch(/^r\./);
+        const base = page.url().split('/p/')[0];
+        await page.goto(`${base}/p/${readOnlyId}`);
+
+        // The plugin still initialises and shows comments on the read-only pad.
+        await expect.poll(async () => page.evaluate(async () => {
+          const ep = (window as any).pad?.plugins?.ep_comments_page;
+          if (!ep || !ep.initDone) return false;
+          await ep.initDone;
+          return true;
+        }), {timeout: 30_000}).toBe(true);
+
+        const roOuter = await getPadOuter(page);
+        await expect.poll(async () =>
+          roOuter.locator('#comments .sidebar-comment').count()).toBeGreaterThan(0);
+
+        // The actions wrapper is present in the DOM but hidden by the CSS.
+        await expect.poll(async () =>
+          roOuter.locator('#comments .comment-actions-wrapper').count()).toBeGreaterThan(0);
+        const display = await roOuter.locator('#comments .comment-actions-wrapper').first()
+            .evaluate((el) => window.getComputedStyle(el).display);
+        expect(display).toBe('none');
+        // And the outer body carries the marker class.
+        expect(await roOuter.locator('#outerdocbody.comments-readonly').count())
+            .toBeGreaterThan(0);
+      });
+});


### PR DESCRIPTION
## Problem

[#112](https://github.com/ether/ep_comments_page/issues/112): on a read-only pad the per-comment **edit** and **delete** controls are still shown, even though the server rejects those writes from a read-only session — so the buttons are dead UI that just confuse read-only viewers.

The comment sidebar (and the mobile modal) live in the `ace_outer` iframe, which doesn't receive core's `readonly` body class, so core's existing `.readonly .acl-write { display: none }` rule never reached them.

## Fix

When `clientVars.readonly` is set, tag the outer body with a `comments-readonly` class and hide `.comment-actions-wrapper` there via the plugin's own CSS. Self-contained — no dependency on the core readonly class reaching the iframe.

Server-side enforcement is unchanged (it already rejected the writes); this only removes the now-dead controls from the UI.

Pure plugin change — works on the latest release (2.7.3) and develop without a core update.

## Test

Adds `readonlyHideActions.spec.ts`: creates a comment, confirms the actions wrapper is visible on the writable pad, then opens the pad's read-only view (`clientVars.readOnlyId`) and asserts the wrapper is present in the DOM but computed `display: none`, and that the outer body carries the `comments-readonly` marker. Verified on **both** Etherpad 2.7.3 and develop.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)