### PR TITLE
feat: show each comment in its author's colour (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ To enable this feature, add the following code to your `settings.json`:
 
 **Warning**: there is a side effect when you enable this feature: a revision is created everytime the text is highlighted, resulting on apparently "empty" changes when you check your pad on the timeslider. If that is an issue for you, we don't recommend you to use this feature.
 
+### Author colour accent
+Each comment box shows a left-border accent in its author's colour. This is on
+by default; disable it with:
+```
+"ep_comments_page": {
+  "showAuthorColor": false
+},
+```
+
 ### Disable HTML export
 By default comments are exported to HTML, but if you don't wish to do that then you can disable it by adding the following to your `settings.json`:
 ```

--- a/index.js
+++ b/index.js
@@ -205,10 +205,13 @@ exports.clientVars = async (hook, context) => {
     settings.ep_comments_page ? settings.ep_comments_page.displayCommentAsIcon : false;
   const highlightSelectedText =
     settings.ep_comments_page ? settings.ep_comments_page.highlightSelectedText : false;
+  // #6: author-colour accent is on unless an admin disables it.
+  const showAuthorColor = !(settings.ep_comments_page &&
+    settings.ep_comments_page.showAuthorColor === false);
   // Merge in the padToggle helper's clientVars block so the client-side
   // helper can read padWideSupported/initialPadEnabled/etc.
   const helperVars = await commentsToggle.clientVars(hook, context);
-  return Object.assign({displayCommentAsIcon, highlightSelectedText}, helperVars);
+  return Object.assign({displayCommentAsIcon, highlightSelectedText, showAuthorColor}, helperVars);
 };
 
 exports.expressCreateServer = (hookName, args, callback) => {

--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -26,6 +26,10 @@
 .sidebar-comment {
   position: absolute;
   width: 100%;
+  box-sizing: border-box;
+  /* Reserve room for the author-colour accent (#6) so commented boxes with and
+     without a known author colour stay aligned; the colour is set inline. */
+  border-left: 3px solid transparent;
 }
 
 /* WITH ICONS */

--- a/static/js/commentBoxes.js
+++ b/static/js/commentBoxes.js
@@ -52,8 +52,14 @@ const highlightComment = (commentId, e, editorComment) => {
     // make a full copy of the html, including listeners
     const commentElmCloned = commentElm.clone(true, true);
 
-    // before of appending clear the css (like top positionning)
+    // Clear only the sidebar positioning so the clone sits correctly in the
+    // modal — but preserve the author-colour accent (#6), which insertComment()
+    // sets as an inline border-left and would otherwise be wiped by clearing
+    // the whole style attribute (#436). Read the inline value off the original
+    // element (the clone may be detached, so computed styles aren't available).
+    const authorBorder = commentElm[0] && commentElm[0].style.borderLeft;
     commentElmCloned.attr('style', '');
+    if (authorBorder) commentElmCloned.css('border-left', authorBorder);
     // fix checkbox, because as we are duplicating the sidebar-comment, we lose unique input names
     commentElmCloned.find('.label-suggestion-checkbox').click(function () {
       $(this).siblings('input[type="checkbox"]').click();

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -615,6 +615,30 @@ EpComments.prototype.insertContainers = function () {
 };
 
 // Insert a comment node
+// Resolve a comment author's Etherpad colour (#6). The current user's colour is
+// always on clientVars.userColor; other authors come from the historical author
+// data core ships in clientVars. colorId is normally a hex string, but resolve a
+// palette index too just in case. Returns null when unknown.
+EpComments.prototype.authorColor = function (authorId) {
+  try {
+    let colorId = null;
+    if (authorId && authorId === clientVars.userId && clientVars.userColor != null) {
+      colorId = clientVars.userColor;
+    } else {
+      const cv = clientVars.collab_client_vars;
+      const data = cv && cv.historicalAuthorData && cv.historicalAuthorData[authorId];
+      colorId = data ? data.colorId : null;
+    }
+    if (colorId == null) return null;
+    // colorId may be a hex string or a palette index, depending on how the
+    // author's colour was stored — resolve the index to a hex either way.
+    if (typeof colorId === 'number') colorId = (clientVars.colorPalette || [])[colorId];
+    return colorId || null;
+  } catch (err) {
+    return null;
+  }
+};
+
 EpComments.prototype.insertComment = function (commentId, comment, index) {
   let content = null;
   const container = this.container;
@@ -630,6 +654,11 @@ EpComments.prototype.insertComment = function (commentId, comment, index) {
   if (comment.author !== clientVars.userId) {
     $(content).find('.comment-actions-wrapper').addClass('hidden');
   }
+  // #6: tag the box with the author's colour as a left-border accent. A border
+  // (rather than text/background colour) keeps the comment readable whatever
+  // the author's pastel happens to be.
+  const color = this.authorColor(comment.author);
+  if (color) content.css('border-left', `3px solid ${color}`);
   commentL10n.localize(content);
 
   // position doesn't seem to be relative to rep

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -621,6 +621,7 @@ EpComments.prototype.insertContainers = function () {
 // palette index too just in case. Returns null when unknown.
 EpComments.prototype.authorColor = function (authorId) {
   try {
+    if (clientVars.showAuthorColor === false) return null;
     let colorId = null;
     if (authorId && authorId === clientVars.userId && clientVars.userColor != null) {
       colorId = clientVars.userColor;

--- a/static/tests/frontend-new/specs/authorColor.spec.ts
+++ b/static/tests/frontend-new/specs/authorColor.spec.ts
@@ -1,0 +1,58 @@
+import {expect, test} from '@playwright/test';
+import {getPadBody, getPadOuter} from 'ep_etherpad-lite/tests/frontend-new/helper/padHelper';
+import {aNewCommentsPad} from '../helper/comments';
+
+// #6: each comment box should carry its author's colour. We render it as a
+// left-border accent (contrast-safe). For the author's own comment the colour
+// is clientVars.userColor; other authors resolve from historicalAuthorData.
+test.describe('ep_comments_page - Author colour accent (#6)', () => {
+  test('comment box border uses the author colour', async ({page}) => {
+    test.setTimeout(60_000);
+    await aNewCommentsPad(page);
+    const inner = await getPadBody(page);
+    const outer = await getPadOuter(page);
+
+    await inner.click();
+    await page.keyboard.press('Control+A');
+    await page.keyboard.press('Delete');
+    await page.keyboard.type('text to be commented by me');
+    await expect.poll(async () => {
+      await inner.locator('div').first().click({clickCount: 3});
+      await page.locator('.addComment').click();
+      return page.locator('#newComment.popup-show').count();
+    }, {timeout: 20_000}).toBeGreaterThan(0);
+    await page.locator('#newComment textarea.comment-content').fill('my comment');
+    await page.locator('#comment-create-btn').click();
+
+    const box = outer.locator('#comments .sidebar-comment').first();
+    await expect.poll(async () => box.count()).toBeGreaterThan(0);
+
+    // clientVars lives on the main pad window, not the ace_outer frame where
+    // the box is, so read the user colour from the page and pass it in. It may
+    // be a palette index, so resolve it to a hex like the plugin does.
+    const userColor: string = await page.evaluate(() => {
+      const cv = (window as any).clientVars;
+      let c = cv.userColor;
+      if (typeof c === 'number') c = cv.colorPalette[c];
+      return c;
+    });
+    expect(userColor).toBeTruthy();
+
+    // The box's left-border colour must equal the current user's colour
+    // (normalise both through the browser so hex vs rgb() doesn't matter).
+    const result = await box.evaluate((el, uc) => {
+      const norm = (c: string) => {
+        const probe = document.createElement('span');
+        probe.style.color = c;
+        document.body.appendChild(probe);
+        const rgb = getComputedStyle(probe).color;
+        probe.remove();
+        return rgb;
+      };
+      return {borderColor: getComputedStyle(el).borderLeftColor, expected: norm(uc)};
+    }, userColor);
+    expect(result.borderColor).toBe(result.expected);
+    // And it must not be the default transparent placeholder.
+    expect(result.borderColor).not.toBe('rgba(0, 0, 0, 0)');
+  });
+});


### PR DESCRIPTION
## What

[#6](https://github.com/ether/ep_comments_page/issues/6): comments should carry their author's colour. This adds a **left-border accent** to each sidebar comment box, tinted with the comment author's Etherpad colour.

- The current user's colour comes from `clientVars.userColor`.
- Other authors resolve from `clientVars.collab_client_vars.historicalAuthorData` (which core ships on both supported cores).
- `colorId` may be a hex or a palette index — both are resolved to a hex.

A border accent (rather than colouring the text or background) keeps the comment readable whatever pastel the author was assigned — avoiding the contrast pitfalls fixed in #380. A transparent placeholder border is reserved in CSS so coloured and unknown-author boxes stay aligned.

Pure plugin change — works on the latest release (2.7.3) and develop without a core update.

## Test

Adds `authorColor.spec.ts`: creates a comment and asserts the box's computed `border-left-color` equals the current user's resolved colour (normalising hex/index/rgb through the browser). Verified on **both** Etherpad 2.7.3 and develop.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)