### PR TITLE
test: lock in cross-pad comment copy (#79)

### DIFF
--- a/static/tests/frontend-new/specs/crossPadCommentCopy.spec.ts
+++ b/static/tests/frontend-new/specs/crossPadCommentCopy.spec.ts
@@ -1,6 +1,6 @@
 import {expect, test} from '@playwright/test';
 import {getPadBody} from 'ep_etherpad-lite/tests/frontend-new/helper/padHelper';
-import {aNewCommentsPad} from '../helper/comments';
+import {aNewCommentsPad, clickAddCommentButton, waitForCommentsInit} from '../helper/comments';
 
 // #79: copying commented text from one pad and pasting it into another should
 // carry the whole comment, not just yellow-highlighted text. The copy handler
@@ -21,27 +21,25 @@ test.describe('ep_comments_page - Cross-pad comment copy (#79)', () => {
     await page.keyboard.type('text copied between pads');
     await expect.poll(async () => {
       await inner.locator('div').first().click({clickCount: 3});
-      await page.locator('.addComment').click();
+      await clickAddCommentButton(page); // disambiguated (.first()) helper
       return page.locator('#newComment.popup-show').count();
     }, {timeout: 20_000}).toBeGreaterThan(0);
     await page.locator('#newComment textarea.comment-content').fill('CROSS_PAD_COMMENT');
     await page.locator('#comment-create-btn').click();
     await expect.poll(async () => inner.locator('.comment').count()).toBeGreaterThan(0);
 
-    // Copy the commented text.
+    // Copy the commented text, then wait until the clipboard actually holds it
+    // (deterministic, instead of a fixed sleep).
     await inner.locator('div').first().locator('.comment').first().click({clickCount: 3});
     await page.keyboard.press('Control+C');
-    await page.waitForTimeout(400);
+    await expect.poll(async () =>
+      page.evaluate(() => navigator.clipboard.readText().catch(() => '')),
+    {timeout: 10_000}).toContain('text copied between pads');
 
     // Pad B: a different pad in the same browser context.
     const base = page.url().split('/p/')[0];
     await page.goto(`${base}/p/cross_pad_dest_${Date.now()}`);
-    await expect.poll(async () => page.evaluate(async () => {
-      const ep = (window as any).pad?.plugins?.ep_comments_page;
-      if (!ep || !ep.initDone) return false;
-      await ep.initDone;
-      return true;
-    }), {timeout: 30_000}).toBe(true);
+    await waitForCommentsInit(page); // shared 60s init wait (no duplicated logic)
 
     inner = await getPadBody(page);
     await inner.click();

--- a/static/tests/frontend-new/specs/crossPadCommentCopy.spec.ts
+++ b/static/tests/frontend-new/specs/crossPadCommentCopy.spec.ts
@@ -28,13 +28,15 @@ test.describe('ep_comments_page - Cross-pad comment copy (#79)', () => {
     await page.locator('#comment-create-btn').click();
     await expect.poll(async () => inner.locator('.comment').count()).toBeGreaterThan(0);
 
-    // Copy the commented text, then wait until the clipboard actually holds it
-    // (deterministic, instead of a fixed sleep).
+    // Copy the commented text. The plugin's copy handler calls preventDefault
+    // and writes custom clipboard types (text/html + text/objectComment), not
+    // text/plain, so the copied payload can't be polled via
+    // navigator.clipboard.readText(); a short settle keeps the synchronous copy
+    // event from racing the navigation below. The real assertion is the paste
+    // result in pad B, which is polled.
     await inner.locator('div').first().locator('.comment').first().click({clickCount: 3});
     await page.keyboard.press('Control+C');
-    await expect.poll(async () =>
-      page.evaluate(() => navigator.clipboard.readText().catch(() => '')),
-    {timeout: 10_000}).toContain('text copied between pads');
+    await page.waitForTimeout(400);
 
     // Pad B: a different pad in the same browser context.
     const base = page.url().split('/p/')[0];

--- a/static/tests/frontend-new/specs/crossPadCommentCopy.spec.ts
+++ b/static/tests/frontend-new/specs/crossPadCommentCopy.spec.ts
@@ -1,0 +1,62 @@
+import {expect, test} from '@playwright/test';
+import {getPadBody} from 'ep_etherpad-lite/tests/frontend-new/helper/padHelper';
+import {aNewCommentsPad} from '../helper/comments';
+
+// #79: copying commented text from one pad and pasting it into another should
+// carry the whole comment, not just yellow-highlighted text. The copy handler
+// puts the comment data on the clipboard and the paste handler recreates the
+// comments in the destination pad (assigning fresh ids). This guards that the
+// comment — with its text — survives a cross-pad copy/paste.
+test.describe('ep_comments_page - Cross-pad comment copy (#79)', () => {
+  test('pasting commented text into another pad brings the comment', async ({page, context}) => {
+    test.setTimeout(60_000);
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+    // Pad A: write text and comment it.
+    await aNewCommentsPad(page);
+    let inner = await getPadBody(page);
+    await inner.click();
+    await page.keyboard.press('Control+A');
+    await page.keyboard.press('Delete');
+    await page.keyboard.type('text copied between pads');
+    await expect.poll(async () => {
+      await inner.locator('div').first().click({clickCount: 3});
+      await page.locator('.addComment').click();
+      return page.locator('#newComment.popup-show').count();
+    }, {timeout: 20_000}).toBeGreaterThan(0);
+    await page.locator('#newComment textarea.comment-content').fill('CROSS_PAD_COMMENT');
+    await page.locator('#comment-create-btn').click();
+    await expect.poll(async () => inner.locator('.comment').count()).toBeGreaterThan(0);
+
+    // Copy the commented text.
+    await inner.locator('div').first().locator('.comment').first().click({clickCount: 3});
+    await page.keyboard.press('Control+C');
+    await page.waitForTimeout(400);
+
+    // Pad B: a different pad in the same browser context.
+    const base = page.url().split('/p/')[0];
+    await page.goto(`${base}/p/cross_pad_dest_${Date.now()}`);
+    await expect.poll(async () => page.evaluate(async () => {
+      const ep = (window as any).pad?.plugins?.ep_comments_page;
+      if (!ep || !ep.initDone) return false;
+      await ep.initDone;
+      return true;
+    }), {timeout: 30_000}).toBe(true);
+
+    inner = await getPadBody(page);
+    await inner.click();
+    await page.keyboard.press('Control+A');
+    await page.keyboard.press('Delete');
+    await page.keyboard.press('Control+V');
+
+    // The comment is recreated in pad B with its original text, and the inline
+    // highlight is present (not just plain/yellow text with no comment).
+    await expect.poll(async () => page.evaluate(async () => {
+      const ep = (window as any).pad.plugins.ep_comments_page;
+      const r = await ep.getComments();
+      const c = (r && r.comments ? r.comments : r) || {};
+      return Object.values(c).map((x: any) => x.text);
+    }), {timeout: 15_000}).toContain('CROSS_PAD_COMMENT');
+    await expect.poll(async () => inner.locator('.comment').count()).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What

[#79](https://github.com/ether/ep_comments_page/issues/79): pasting commented text from one pad into another used to bring only the text (highlighted yellow) without the comment. This **now works** — the copy handler puts the comment data on the clipboard and the paste handler recreates the comments (with fresh ids) in the destination pad.

I verified end-to-end (Chromium): comment text in pad A → copy → paste into a *different* pad → the comment is recreated there with its original text and inline highlight (`storedComments=1`, `texts=CROSS_PAD_COMMENT`). The original report predates the clipboard-data copy/paste mechanism; modern Chromium preserves the custom clipboard format across documents, so it functions today.

Rather than touch the (intricate, historically skip-tested) copy/paste code, this adds a **regression test** to lock the behaviour in.

## Test

Adds `crossPadCommentCopy.spec.ts`: comments text in one pad, copies it, navigates to a different pad in the same browser context, pastes, and asserts the comment is recreated there with its text and a `.comment` highlight. Passes on **both** Etherpad 2.7.3 and develop.

Note: this relies on the browser preserving the custom clipboard format across documents (true in the Chromium that CI runs). Browsers that sanitise custom formats would still need the data embedded in the copied HTML — a possible follow-up if non-Chromium support is required.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)